### PR TITLE
Add Discord support

### DIFF
--- a/docs/js/crate.js
+++ b/docs/js/crate.js
@@ -1,0 +1,5 @@
+new Crate({
+    server: '735877944085446747',
+    channel: '735877944517591151'
+})
+crate.notify('Have questions? Join us!')

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -32,8 +32,8 @@ extra_javascript:
 - https://unpkg.com/mermaid@8.4.6/dist/mermaid.min.js
 - js/termynal.js
 - js/custom.js
-- js/chat.js
-- https://sidecar.gitter.im/dist/sidecar.v1.js
+- https://cdn.jsdelivr.net/npm/@widgetbot/crate@3
+- js/crate.js
 
 nav:
   - Home: index.md


### PR DESCRIPTION
I added Discord support. A Discord button appears on the right bottom corner: Clicking it makes the Mantisshrimp General channel appears.  A new user can join our server. Existing Mantisshrimp Discord members can send chat right from the Docs!