### PR TITLE
Updated site url

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -10,7 +10,7 @@ theme:
 
 docs_dir: sources
 repo_url: https://github.com/airctic/IceVision
-site_url: https://icevision.airctic.com/
+site_url: https://airctic.com/
 edit_uri: ""
 site_description: 'Documentation for IceVision.'
 # google_analytics: ['UA-44322747-3', 'https://airctic.github.io/icevision/']


### PR DESCRIPTION
I update the site_url to airctic.com! It looks like this now:

![image](https://user-images.githubusercontent.com/59614262/92346712-9e9e6800-f09b-11ea-979d-bf3c7622dbae.png)
