### PR TITLE
Fixed weights urls

### DIFF
--- a/docs/HOW-TO.md
+++ b/docs/HOW-TO.md
@@ -124,7 +124,7 @@ class_map = datasets.pets.class_map()
 IMAGE_URL = "https://petcaramelo.com/wp-content/uploads/2018/06/beagle-cachorro.jpg"
 IMG_PATH = "tmp.jpg"
 # Model trained on `Tutorials->Getting Started`
-WEIGHTS_URL = "https://icevision-models.s3.us-east-2.amazonaws.com/pets.zip"
+WEIGHTS_URL = "https://github.com/airctic/model_zoo/releases/download/pets_faster_resnet50fpn/pets_faster_resnetfpn50.zip"
 
 # Download and open image, optionally show it
 download_url(IMAGE_URL, IMG_PATH)
@@ -193,7 +193,7 @@ In this example, we show how to create a Faster RCNN model, and load pretrained 
 class_map = datasets.pets.class_map()
 
 # Model trained in `Tutorials->Getting Started`
-WEIGHTS_URL = "https://icevision-models.s3.us-east-2.amazonaws.com/pets.zip"
+WEIGHTS_URL = "https://github.com/airctic/model_zoo/releases/download/pets_faster_resnet50fpn/pets_faster_resnetfpn50.zip"
 
 # Create the same model used in training and load the weights
 # `map_location` will put the model on cpu, optionally move to gpu if necessary

--- a/examples/inference.md
+++ b/examples/inference.md
@@ -17,7 +17,7 @@ class_map = datasets.pets.class_map()
 IMAGE_URL = "https://petcaramelo.com/wp-content/uploads/2018/06/beagle-cachorro.jpg"
 IMG_PATH = "tmp.jpg"
 # Model trained in `Tutorials->Getting Started`
-WEIGHTS_URL = "https://icevision-models.s3.us-east-2.amazonaws.com/pets.zip"
+WEIGHTS_URL = "https://github.com/airctic/model_zoo/releases/download/pets_faster_resnet50fpn/pets_faster_resnetfpn50.zip"
 
 # Download and open image, optionally show it
 download_url(IMAGE_URL, IMG_PATH)

--- a/notebooks/inference.ipynb
+++ b/notebooks/inference.ipynb
@@ -138,7 +138,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "WEIGHTS_URL = \"https://icevision-models.s3.us-east-2.amazonaws.com/pets.zip\"\n",
+    "WEIGHTS_URL = \"https://github.com/airctic/model_zoo/releases/download/fridge_tf_efficientdet_lite0/fridge_tf_efficientdet_lite0.zip\"\n",
     "state_dict = torch.hub.load_state_dict_from_url(WEIGHTS_URL, map_location=torch.device(\"cpu\"))"
    ]
   },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,7 @@ def fridge_efficientdet_records(samples_source):
 
 @pytest.fixture()
 def fridge_efficientdet_model() -> nn.Module:
-    WEIGHTS_URL = "https://mantisshrimp-models.s3.us-east-2.amazonaws.com/fridge_tf_efficientdet_lite0.zip"
+    WEIGHTS_URL = "https://github.com/airctic/model_zoo/releases/download/fridge_tf_efficientdet_lite0/fridge_tf_efficientdet_lite0.zip"
     model = efficientdet.model("tf_efficientdet_lite0", num_classes=5, img_size=512)
 
     state_dict = torch.hub.load_state_dict_from_url(


### PR DESCRIPTION
I updated the WEIGHTS_URL to point to the corresponding files stored in https://github.com/airctic/model_zoo/releases