### PR TITLE
Updated Notebooks Documentation to remove Data Splitter. For issue #432

### DIFF
--- a/examples/backbones_faster_rcnn.md
+++ b/examples/backbones_faster_rcnn.md
@@ -29,8 +29,7 @@ In this example, we are training the Raccoon dataset using either [Fastai](https
     )
 
     # train and validation records
-    data_splitter = RandomSplitter([0.8, 0.2])
-    train_records, valid_records = parser.parse(data_splitter)
+    train_records, valid_records = parser.parse()
 
     # Datasets
     # Transforms
@@ -125,8 +124,7 @@ In this example, we are training the Raccoon dataset using either [Fastai](https
     )
 
     # train and validation records
-    data_splitter = RandomSplitter([0.8, 0.2])
-    train_records, valid_records = parser.parse(data_splitter)
+    train_records, valid_records = parser.parse()
 
     # Datasets
     # Transforms

--- a/examples/dataset_voc_exp.md
+++ b/examples/dataset_voc_exp.md
@@ -30,8 +30,7 @@ This notebook shows a special use case of training a VOC compatible dataset usin
     )
 
     # train and validation records
-    data_splitter = RandomSplitter([0.8, 0.2])
-    train_records, valid_records = parser.parse(data_splitter)
+    train_records, valid_records = parser.parse()
     show_records(train_records[:3], ncols=3, class_map=class_map)
 
     # Datasets
@@ -126,8 +125,7 @@ This notebook shows a special use case of training a VOC compatible dataset usin
     )
 
     # train and validation records
-    data_splitter = RandomSplitter([0.8, 0.2])
-    train_records, valid_records = parser.parse(data_splitter)
+    train_records, valid_records = parser.parse()
     show_records(train_records[:3], ncols=3, class_map=class_map)
 
     # Datasets

--- a/examples/efficientdet_pets_exp.md
+++ b/examples/efficientdet_pets_exp.md
@@ -20,8 +20,7 @@ In this example, we show how to train an EffecientDet model on the PETS dataset 
     # Parser
     class_map = icedata.pets.class_map()
     parser = icedata.pets.parser(data_dir, class_map)
-    data_splitter = RandomSplitter([0.8, 0.2])
-    train_records, valid_records = parser.parse(data_splitter)
+    train_records, valid_records = parser.parse()
     show_records(train_records[:3], ncols=3, class_map=class_map)
 
     # Datasets
@@ -102,8 +101,7 @@ In this example, we show how to train an EffecientDet model on the PETS dataset 
     # Parser
     class_map = icedata.pets.class_map()
     parser = icedata.pets.parser(data_dir, class_map)
-    data_splitter = RandomSplitter([0.8, 0.2])
-    train_records, valid_records = parser.parse(data_splitter)
+    train_records, valid_records = parser.parse()
     show_records(train_records[:3], ncols=3, class_map=class_map)
 
     # Datasets

--- a/examples/how_train_dataset_exp.md
+++ b/examples/how_train_dataset_exp.md
@@ -20,8 +20,7 @@ In this example, we are training the Fridge Objects dataset using either [Fastai
     # Parser
     class_map = icedata.fridge.class_map()
     parser = icedata.fridge.parser(data_dir, class_map)
-    data_splitter = RandomSplitter([0.8, 0.2])
-    train_records, valid_records = parser.parse(data_splitter)
+    train_records, valid_records = parser.parse()
     show_records(train_records[:3], ncols=3, class_map=class_map)
 
     # Datasets
@@ -101,8 +100,7 @@ In this example, we are training the Fridge Objects dataset using either [Fastai
     # Parser
     class_map = icedata.fridge.class_map()
     parser = icedata.fridge.parser(data_dir, class_map)
-    data_splitter = RandomSplitter([0.8, 0.2])
-    train_records, valid_records = parser.parse(data_splitter)
+    train_records, valid_records = parser.parse()
     show_records(train_records[:3], ncols=3, class_map=class_map)
 
     # Datasets

--- a/examples/pennfudan.md
+++ b/examples/pennfudan.md
@@ -18,8 +18,7 @@ This shows how to train a MaskRCNN model on  the [Penn-Fundan](https://www.cis.u
     parser = icedata.pennfudan.parser(data_dir)
 
     # Parse records with random splits
-    data_splitter = RandomSplitter([0.8, 0.2])
-    train_records, valid_records = parser.parse(data_splitter)
+    train_records, valid_records = parser.parse()
 
     # Define the transforms and create the Datasets
     presize = 512
@@ -87,9 +86,8 @@ This shows how to train a MaskRCNN model on  the [Penn-Fundan](https://www.cis.u
     class_map = icedata.pennfudan.class_map()
     parser = icedata.pennfudan.parser(data_dir)
 
-    # Parse records with random splits
-    data_splitter = RandomSplitter([0.8, 0.2])
-    train_records, valid_records = parser.parse(data_splitter)
+
+    train_records, valid_records = parser.parse()
 
     # Define the transforms and create the Datasets
     presize = 512

--- a/examples/training.md
+++ b/examples/training.md
@@ -18,8 +18,7 @@ In this example, we are training the PETS dataset using either [Fastai](https://
     # Get the class_map, a utility that maps from number IDs to classs names
     class_map = icedata.pets.class_map()
 
-    # Randomly split our data into train/valid
-    data_splitter = RandomSplitter([0.8, 0.2])
+    
 
     # PETS parser: provided out-of-the-box
     parser = icedata.pets.parser(data_dir=path, class_map=class_map)
@@ -69,9 +68,6 @@ In this example, we are training the PETS dataset using either [Fastai](https://
 
     # Get the class_map, a utility that maps from number IDs to classs names
     class_map = icedata.pets.class_map()
-
-    # Randomly split our data into train/valid
-    data_splitter = RandomSplitter([0.8, 0.2])
 
     # PETS parser: provided out-of-the-box
     parser = icedata.pets.parser(data_dir=path, class_map=class_map)


### PR DESCRIPTION
RandomSplitter is now passed by default. Therefore, I have updated the notebooks, in the notebooks folder.

1- The following line is removed:

# Randomly split our data into train/valid
data_splitter = RandomSplitter([0.8, 0.2])
2- The following line is modified: removed data_splitter from the parser.parse() call
Before:

train_records, valid_records = parser.parse(data_splitter)
After:

train_records, valid_records = parser.parse()