### PR TITLE
Update quickstart_exp.md

### DIFF
--- a/examples/quickstart_exp.md
+++ b/examples/quickstart_exp.md
@@ -17,8 +17,8 @@ In this example, we are training the Fridge Objects dataset using either [Fastai
 
     # Parser
     class_map = ClassMap(["milk_bottle", "carton", "can", "water_bottle"])
-    parser = parsers.voc(annotations_dir=data_dir / "odFridgeObjects/images/",
-                        images_dir=data_dir / "odFridgeObjects/annotations",
+    parser = parsers.voc(annotations_dir=data_dir / "odFridgeObjects/annotations/",
+                        images_dir=data_dir / "odFridgeObjects/images",
                         class_map=class_map)
 
     # Records


### PR DESCRIPTION
Assigned correct path for annotations_dir and images_dir in Parser section.


```
#Parser
class_map = ClassMap(["milk_bottle", "carton", "can", "water_bottle"])
parser = parsers.voc(annotations_dir=data_dir / "odFridgeObjects/images/",
                    images_dir=data_dir / "odFridgeObjects/annotations",
                    class_map=class_map)
```


Corrected to:

```
#Parser
class_map = ClassMap(["milk_bottle", "carton", "can", "water_bottle"])
parser = parsers.voc(annotations_dir=data_dir / "odFridgeObjects/annotations/",
                    images_dir=data_dir / "odFridgeObjects/images",
                    class_map=class_map)
```