### PR TITLE
Added pretrained argument to Mask-RCNN model definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Cache records after parsing with the new parameter `cache_filepath` added to `Parser.parse` (#504)
+- Added `pretrained: bool = True` argument to both faster_rcnn and mask_rcnn `model()` methods. (#516)
 
 ### Changed
 

--- a/icevision/models/rcnn/faster_rcnn/model.py
+++ b/icevision/models/rcnn/faster_rcnn/model.py
@@ -24,9 +24,9 @@ def model(
         remove_internal_transforms: The torchvision model internally applies transforms
         like resizing and normalization, but we already do this at the `Dataset` level,
         so it's safe to remove those internal transforms.
-        pretrained: Argument passed to `maskrcnn_resnet50_fpn` if `backbone is None`. 
-        By default it is set to True: this is generally used when training a new model (transfer learning). 
-        `pretrained = False`  is used during inference (prediction) for cases where the users have their own pretrained weights. 
+        pretrained: Argument passed to `maskrcnn_resnet50_fpn` if `backbone is None`.
+        By default it is set to True: this is generally used when training a new model (transfer learning).
+        `pretrained = False`  is used during inference (prediction) for cases where the users have their own pretrained weights.
         **faster_rcnn_kwargs: Keyword arguments that internally are going to be passed to
         `torchvision.models.detection.faster_rcnn.FastRCNN`.
 

--- a/icevision/models/rcnn/faster_rcnn/model.py
+++ b/icevision/models/rcnn/faster_rcnn/model.py
@@ -13,6 +13,7 @@ def model(
     num_classes: int,
     backbone: Optional[nn.Module] = None,
     remove_internal_transforms: bool = True,
+    pretrained: bool = True,
     **faster_rcnn_kwargs
 ) -> nn.Module:
     """FasterRCNN model implemented by torchvision.
@@ -23,6 +24,9 @@ def model(
         remove_internal_transforms: The torchvision model internally applies transforms
         like resizing and normalization, but we already do this at the `Dataset` level,
         so it's safe to remove those internal transforms.
+        pretrained: Argument passed to `maskrcnn_resnet50_fpn` if `backbone is None`. 
+        By default it is set to True: this is generally used when training a new model (transfer learning). 
+        `pretrained = False`  is used during inference (prediction) for cases where the users have their own pretrained weights. 
         **faster_rcnn_kwargs: Keyword arguments that internally are going to be passed to
         `torchvision.models.detection.faster_rcnn.FastRCNN`.
 

--- a/icevision/models/rcnn/mask_rcnn/model.py
+++ b/icevision/models/rcnn/mask_rcnn/model.py
@@ -25,9 +25,9 @@ def model(
         remove_internal_transforms: The torchvision model internally applies transforms
         like resizing and normalization, but we already do this at the `Dataset` level,
         so it's safe to remove those internal transforms.
-        pretrained: Argument passed to `maskrcnn_resnet50_fpn` if `backbone is None`. 
-        By default it is set to True: this is generally used when training a new model (transfer learning). 
-        `pretrained = False`  is used during inference (prediction) for cases where the users have their own pretrained weights. 
+        pretrained: Argument passed to `maskrcnn_resnet50_fpn` if `backbone is None`.
+        By default it is set to True: this is generally used when training a new model (transfer learning).
+        `pretrained = False`  is used during inference (prediction) for cases where the users have their own pretrained weights.
         **mask_rcnn_kwargs: Keyword arguments that internally are going to be passed to
         `torchvision.models.detection.mask_rcnn.MaskRCNN`.
 

--- a/icevision/models/rcnn/mask_rcnn/model.py
+++ b/icevision/models/rcnn/mask_rcnn/model.py
@@ -14,6 +14,7 @@ def model(
     num_classes: int,
     backbone: Optional[nn.Module] = None,
     remove_internal_transforms: bool = True,
+    pretrained: bool = True
     **mask_rcnn_kwargs
 ) -> nn.Module:
     """MaskRCNN model implemented by torchvision.
@@ -31,7 +32,7 @@ def model(
         A Pytorch `nn.Module`.
     """
     if backbone is None:
-        model = maskrcnn_resnet50_fpn(pretrained=True, **mask_rcnn_kwargs)
+        model = maskrcnn_resnet50_fpn(pretrained=pretrained, **mask_rcnn_kwargs)
 
         in_features_box = model.roi_heads.box_predictor.cls_score.in_features
         model.roi_heads.box_predictor = FastRCNNPredictor(in_features_box, num_classes)

--- a/icevision/models/rcnn/mask_rcnn/model.py
+++ b/icevision/models/rcnn/mask_rcnn/model.py
@@ -14,7 +14,7 @@ def model(
     num_classes: int,
     backbone: Optional[nn.Module] = None,
     remove_internal_transforms: bool = True,
-    pretrained: bool = True
+    pretrained: bool = True,
     **mask_rcnn_kwargs
 ) -> nn.Module:
     """MaskRCNN model implemented by torchvision.

--- a/icevision/models/rcnn/mask_rcnn/model.py
+++ b/icevision/models/rcnn/mask_rcnn/model.py
@@ -25,6 +25,9 @@ def model(
         remove_internal_transforms: The torchvision model internally applies transforms
         like resizing and normalization, but we already do this at the `Dataset` level,
         so it's safe to remove those internal transforms.
+        pretrained: Argument passed to `maskrcnn_resnet50_fpn` if `backbone is None`. 
+        By default it is set to True: this is generally used when training a new model (transfer learning). 
+        `pretrained = False`  is used during inference (prediction) for cases where the users have their own pretrained weights. 
         **mask_rcnn_kwargs: Keyword arguments that internally are going to be passed to
         `torchvision.models.detection.mask_rcnn.MaskRCNN`.
 


### PR DESCRIPTION
Added pretrained argument to Mask-RCNN model definition to avoid systematically loading the pretrained weights. This covers the scenario where we already have another pretrained weights such the PennFudan model.