### PR TITLE
Issue 534 : Add precommit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+ignore = E203, E266, E501, W503, F403, F401, F405
+# from ci-all-testing.yaml
+select = E9,F63,F7,F82
+# `--exit-zero` can't be set in config
+# max-line-length = 127
+# max-complexity = 10

--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,6 @@
 ignore = E203, E266, E501, W503, F403, F401, F405
 # from ci-all-testing.yaml
 select = E9,F63,F7,F82
+max-line-length = 127
 # `--exit-zero` can't be set in config
-# max-line-length = 127
 # max-complexity = 10

--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-ignore = E203, E266, E501, W503, F403, F401, F405
-# from ci-all-testing.yaml
-select = E9,F63,F7,F82
-max-line-length = 127
-# `--exit-zero` can't be set in config
-# max-complexity = 10

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+*env*/
 build/
 develop-eggs/
 dist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,5 +8,5 @@ repos:
     rev: "3.8.3"
     hooks:
       - id: flake8
-        args: ["--config=.flake8"]
+        args: ["--config=setup.cfg"]
         language_version: python3.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+        language_version: python3.8
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: "3.8.3"
+    hooks:
+      - id: flake8
+        args: ["--config=.flake8"]
+        language_version: python3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,4 +61,6 @@ dev =
   Sphinx >=3.1.0,<4
   pytest-cov >=2.10.1,<3
   flake8 >=3.8.3,<4
+  pre-commit >=2.8.2,<3
+
   

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,4 +63,6 @@ dev =
   flake8 >=3.8.3,<4
   pre-commit >=2.8.2,<3
 
-  
+[flake8]
+# from ci-all-testing.yaml
+select = E9,F63,F7,F82


### PR DESCRIPTION
- `flake8` has an `--exit-zero` in CI which is currently commented out in `.flake8` - as they're incompatible 
- minor update in `.gitignore` : to exclude venv like `pythonenv3.8`

*btw, is it preferable to squash the 3 commits into a single one?*

##### the documentation needs to be upgraded as well, but, let's have that after this gets reviewed/merged