### PR TITLE
Update CI - include pre-commit (black and flake8)

### DIFF
--- a/.github/workflows/ci-all-testing.yml
+++ b/.github/workflows/ci-all-testing.yml
@@ -16,30 +16,36 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install package
-      run: pip install -e ".[all,dev]"
+      - name: Install package
+        run: pip install -e ".[all,dev]"
 
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Run pre-commit
+        run: |
+          pre-commit install
+          # covers black and flake8 E9,F63,F7,F82
+          pre-commit run --all-files
 
-    - name: Run tests
-      run: pytest tests -m "not cuda" --cov=icevision --cov-report=xml --color=yes
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: false
+      - name: Run tests
+        run: pytest tests -m "not cuda" --cov=icevision --cov-report=xml --color=yes
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false


### PR DESCRIPTION
removes the need for separate CI for `black`
and `flake8 (E9 ...)` is also covered