### PR TITLE
Error in Inference tutorial for show_preds

### DIFF
--- a/notebooks/inference.ipynb
+++ b/notebooks/inference.ipynb
@@ -371,7 +371,7 @@
     "# Show preds by grabbing the images from `samples`\n",
     "imgs = [sample[\"img\"] for sample in samples]\n",
     "show_preds(\n",
-    "    imgs=imgs,\n",
+    "    samples=imgs,\n",
     "    preds=preds,\n",
     "    class_map=class_map,\n",
     "    denormalize_fn=denormalize_imagenet,\n",
@@ -405,7 +405,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Corrected the documentation for the inference tutorial as mentioned in "Error in Inference tutorial for show_preds() #558"