### PR TITLE
Added label_field to VIA parser for alternate region_attribute names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `aggregate_records_objects` function
 
 ### Changed
+- Added `label_field` to VIA parser to allow for alternate `region_attribute` names
+ 
 ### Deleted
 
 ## [0.5.0]

--- a/samples/via/via_bbox.json
+++ b/samples/via/via_bbox.json
@@ -20,7 +20,11 @@
                     ]
                 },
                 "region_attributes": {
-                    "label": "z"
+                    "label": "z",
+                    "object": "z",
+                    "qualities": {
+                        "is_rotated": true
+                    }
                 }
             },
             {
@@ -42,7 +46,11 @@
                     ]
                 },
                 "region_attributes": {
-                    "label": "c"
+                    "label": "c",
+                    "object": "c",
+                    "qualities": {
+                        "is_rotated": true
+                    }
                 }
             },
             {
@@ -62,7 +70,11 @@
                     ]
                 },
                 "region_attributes": {
-                    "label": "o"
+                    "label": "o",
+                    "object": "o",
+                    "qualities": {
+                        "is_rotated": true
+                    }
                 }
             },
             {
@@ -82,7 +94,12 @@
                     ]
                 },
                 "region_attributes": {
-                    "label": "###"
+                    "label": "###",
+                    "object": "o",
+                    "qualities": {
+                        "is_rotated": true,
+                        "is_inverted": true
+                    }
                 }
             },
             {
@@ -94,7 +111,8 @@
                     "height": 48
                 },
                 "region_attributes": {
-                    "label": "n"
+                    "label": "n",
+                    "object": "n"
                 }
             }
         ],
@@ -121,7 +139,11 @@
                     ]
                 },
                 "region_attributes": {
-                    "label": "z"
+                    "label": "z",
+                    "object": "z",
+                    "qualities": {
+                        "is_rotated": true
+                    }
                 }
             },
             {
@@ -141,7 +163,11 @@
                     ]
                 },
                 "region_attributes": {
-                    "label": "c"
+                    "label": "c",
+                    "object": "c",
+                    "qualities": {
+                        "is_rotated": true
+                    }
                 }
             },
             {
@@ -161,7 +187,11 @@
                     ]
                 },
                 "region_attributes": {
-                    "label": "n"
+                    "label": "n",
+                    "object": "n",
+                    "qualities": {
+                        "is_rotated": true
+                    }
                 }
             },
             {
@@ -181,7 +211,11 @@
                     ]
                 },
                 "region_attributes": {
-                    "label": "o"
+                    "label": "o",
+                    "object": "o",
+                    "qualities": {
+                        "is_rotated": true
+                    }
                 }
             },
             {
@@ -201,7 +235,11 @@
                     ]
                 },
                 "region_attributes": {
-                    "label": "###"
+                    "label": "###",
+                    "object": "o",
+                    "qualities": {
+                        "is_inverted": true
+                    }
                 }
             }
         ],

--- a/tests/parsers/test_via_parser.py
+++ b/tests/parsers/test_via_parser.py
@@ -2,13 +2,9 @@ import pytest
 from icevision.all import *
 
 
-@pytest.fixture
-def via_bbox_parser(via_dir, via_bbox_class_map):
-    return parsers.via(via_dir / "via_bbox.json", via_dir, via_bbox_class_map)
-
-
-def test_bbox_parser(via_dir, via_bbox_parser):
-    records = via_bbox_parser.parse(data_splitter=SingleSplitSplitter())[0]
+def test_bbox_parser(via_dir, via_bbox_class_map):
+    parser = parsers.via(via_dir / "via_bbox.json", via_dir, via_bbox_class_map)
+    records = parser.parse(data_splitter=SingleSplitSplitter())[0]
     assert len(records) == 2
 
     record = records[0]
@@ -22,3 +18,30 @@ def test_bbox_parser(via_dir, via_bbox_parser):
     assert record.bboxes[0].xyxy == (104, 120, 155, 176)
     # Rect
     assert record.bboxes[3].xyxy == (263, 55, 308, 103)
+
+
+def test_bbox_parser_alt_label(via_dir, via_bbox_class_map):
+    parser = parsers.via(
+        via_dir / "via_bbox.json", via_dir, via_bbox_class_map, label_field="object"
+    )
+    records = parser.parse(data_splitter=SingleSplitSplitter())[0]
+    record = records[0]
+    # Additional label is found when using the 'object' label_field.
+    # When 'label' is used, one region is marked '###' and therefore not found in class_map.
+    assert record.labels == [4, 1, 3, 3, 2]
+
+
+def test_bbox_parser_broken_label(via_dir, via_bbox_class_map):
+    parser = parsers.via(
+        via_dir / "via_bbox.json", via_dir, via_bbox_class_map, label_field="qualities"
+    )
+    with pytest.raises(parsers.VIAParseError, match=r"Non-string.*IMG_4908.*"):
+        _ = parser.parse(data_splitter=SingleSplitSplitter())[0]
+
+
+def test_bbox_parser_missing_label(via_dir, via_bbox_class_map):
+    parser = parsers.via(
+        via_dir / "via_bbox.json", via_dir, via_bbox_class_map, label_field="MISSING"
+    )
+    with pytest.raises(parsers.VIAParseError, match=r"Could not find.*IMG_4908.*"):
+        _ = parser.parse(data_splitter=SingleSplitSplitter())[0]


### PR DESCRIPTION
In VGG Image Annotator v2 you can specify any name for the `region_attributes`. One of these attributes holds the `label` that IceVision requires to associate with the bbox. The previous implementation of the parser made an assumption that this attribute would be named `label` and therefore would otherwise fail.

It's also possible to add multiple `region_attributes` and they can be complex types rather than simple strings. See the `qualities` attribute from the annotator:
![image](https://user-images.githubusercontent.com/1909032/102018249-4205b580-3d3a-11eb-996a-177fe9d335ae.png)
Region 1 above appears as:
```json
"region_attributes": {
  "label": "z",
  "object": "z",
  "qualities": {
    "is_rotated": true
  }
}
```
Two changes are made in this PR.
- A `label_field` parameter is added to the VIA parser which defaults to `label` for backwards compatibility.
- A `VIAParseError` exception is raised during parsing if an attempt is made to parse a non-string or missing region_attribute.
