### PR TITLE
Add `VIAMaskParser` for parsing polygons as mask annotations.

### DIFF
--- a/icevision/parsers/via_parser.py
+++ b/icevision/parsers/via_parser.py
@@ -11,7 +11,7 @@ def via(
     img_dir: Union[str, Path],
     class_map: ClassMap,
     label_field: str = "label",
-    mask: bool = True,
+    mask: bool = False,
 ) -> Parser:
     """
     Parser for JSON annotations from the VGG Image Annotator V2.

--- a/icevision/parsers/via_parser.py
+++ b/icevision/parsers/via_parser.py
@@ -142,7 +142,7 @@ class VIAMaskParser(VIABBoxParser, MasksMixin):
                     ]
 
                     # create empty image and fill it with the polygon
-                    # mask_img = PIL.Image.new("L", get_image_size(self.filepath(o)), 0)
+                    mask_img = PIL.Image.new("L", get_image_size(self.filepath(o)), 0)
                     PIL.ImageDraw.Draw(mask_img).polygon(xy_coords, outline=1, fill=1)
 
                     # return binary mask array from created image


### PR DESCRIPTION
In order to do this, I had to remove `VIABBoxParser`'s ability to parse bounding boxes from both `rect` and `polygon` shape attributes and assume that `rect` annotations are for bounding boxes and `polygon` annotations for masks. If not, then the polygon annotations were added as an additional bbox and this didn't allow it to be parsed due to length mismatch betwen number of boxes and masks.

I've left some of the older code commented out rather than delete it, will be happy to clean that up after some feedback.