### PR TITLE
Tutorial for how to use FixedSplitter

### DIFF
--- a/notebooks/voc_predefined_splits.ipynb
+++ b/notebooks/voc_predefined_splits.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a href=\"https://colab.research.google.com/github/airctic/icevision/blob/master/notebooks/voc_predefined_splits.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# How to parse a voc dataset using predefined splits"
    ]
   },
@@ -20,8 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install icevision[all]\n",
-    "!pip install icedata"
+    "!pip install git+git://github.com/airctic/icevision.git"
    ]
   },
   {
@@ -30,8 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from icevision import *\n",
-    "import icedata"
+    "from icevision.all import * "
    ]
   },
   {
@@ -69,16 +74,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# images = os.listdir(images_dir)\n",
-    "# idmap = IDMap(images)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -99,6 +94,13 @@
    "metadata": {},
    "source": [
     "## Split data using imagesets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "ImageSets directory contains multiple text files containing subsets of images from JPEGImages. We can use these files to select subsets of our data ie aeroplanes. The values we need to pass to FixedSplitter are the values returned by imageid in our parser rather than the filenames."
    ]
   },
   {
@@ -137,16 +139,6 @@
     "parser = parsers.voc(\n",
     "    annotations_dir=annotations_dir, images_dir=images_dir, class_map=class_map\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# splits = data_splitter(idmap=idmap)\n",
-    "# print(splits)"
    ]
   },
   {

--- a/notebooks/voc_predefined_splits.ipynb
+++ b/notebooks/voc_predefined_splits.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# How to parse a voc dataset using predefined splits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install and import IceVision and IceData"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install icevision[all]\n",
+    "!pip install icedata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from icevision import *\n",
+    "import icedata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Pascal VOC 2012 dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path = icedata.voc.load_data()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set images, annotations and imagesets directories"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "annotations_dir = path / \"Annotations\"\n",
+    "images_dir = path / \"JPEGImages\"\n",
+    "imagesets_dir = path / \"ImageSets/Main\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# images = os.listdir(images_dir)\n",
+    "# idmap = IDMap(images)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define class_map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class_map = icedata.voc.class_map()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Split data using imagesets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train = [(line.split(\" \",1)[0]) for line in open(imagesets_dir / \"aeroplane_train.txt\")]\n",
+    "val = [(line.split(\" \",1)[0]) for line in open(imagesets_dir / \"aeroplane_val.txt\")]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "presplits = [train, val]\n",
+    "data_splitter = FixedSplitter(presplits)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Parser: use icevision predefined VOC parser"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parser = parsers.voc(\n",
+    "    annotations_dir=annotations_dir, images_dir=images_dir, class_map=class_map\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# splits = data_splitter(idmap=idmap)\n",
+    "# print(splits)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train and validation records"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_records, valid_records = parser.parse(data_splitter)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_records(train_records[:2], ncols=2, class_map=class_map)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This tutorial shows how to split a dataset using predefined imagesets as specified in issue #585. The dataset used within the tutorial is Pascal VOC 2012. This tutorial will only work using the latest icedata (the one via PyPI won't work as specified in "AttributeError: module 'icedata' has no attribute 'voc' #84") with my proposed changes in PR "Add voc data functions #91". 