### PR TITLE
removed images from records accumulated in validation

### DIFF
--- a/icevision/metrics/coco_metric/coco_metric.py
+++ b/icevision/metrics/coco_metric/coco_metric.py
@@ -41,6 +41,9 @@ class COCOMetric(Metric):
         self._preds.clear()
 
     def accumulate(self, records, preds):
+        # to not store whole images and avoid excess memory use
+        for record in records:
+            record.pop("img", None)
         self._records.extend(records)
         self._preds.extend(preds)
 


### PR DESCRIPTION
I figured out the memory leak in COCOMetrics. Records were stored as whole, together with images.