### PR TITLE
docs(examples): fixes undefined variable 'size' in getting_started_exp

### DIFF
--- a/examples/getting_started_exp.md
+++ b/examples/getting_started_exp.md
@@ -31,7 +31,7 @@ In this example, we are training the PETS dataset using either [Fastai](https://
     train_tfms = tfms.A.Adapter(
         [*tfms.A.aug_tfms(size=384, presize=512), tfms.A.Normalize()]
     )
-    valid_tfms = tfms.A.Adapter([*tfms.A.resize_and_pad(size), tfms.A.Normalize()])
+    valid_tfms = tfms.A.Adapter([*tfms.A.resize_and_pad(384), tfms.A.Normalize()])
     # Create both training and validation datasets
     train_ds = Dataset(train_records, train_tfms)
     valid_ds = Dataset(valid_records, valid_tfms)


### PR DESCRIPTION
The variable `size` wasn't initialized, which would cause an issue at runtime.

I took a brief look at the Jupiter notebook for this example, and there's a separate cell where the `size` and `presize` are defined in a separate cell. I opted to inline this value rather than extract it as a separate value, as this example already favored having these magic constants in-line.