### PR TITLE
docs(examples): fixes download url to weights of the pets dataset

### DIFF
--- a/docs/HOW-TO.md
+++ b/docs/HOW-TO.md
@@ -124,7 +124,7 @@ class_map = datasets.pets.class_map()
 IMAGE_URL = "https://petcaramelo.com/wp-content/uploads/2018/06/beagle-cachorro.jpg"
 IMG_PATH = "tmp.jpg"
 # Model trained on `Tutorials->Getting Started`
-WEIGHTS_URL = "https://github.com/airctic/model_zoo/releases/download/pets_faster_resnet50fpn/pets_faster_resnetfpn50.zip"
+WEIGHTS_URL = "https://github.com/airctic/model_zoo/releases/download/m3/pets_faster_resnetfpn50.zip"
 
 # Download and open image, optionally show it
 download_url(IMAGE_URL, IMG_PATH)
@@ -193,7 +193,7 @@ In this example, we show how to create a Faster RCNN model, and load pretrained 
 class_map = datasets.pets.class_map()
 
 # Model trained in `Tutorials->Getting Started`
-WEIGHTS_URL = "https://github.com/airctic/model_zoo/releases/download/pets_faster_resnet50fpn/pets_faster_resnetfpn50.zip"
+WEIGHTS_URL = "https://github.com/airctic/model_zoo/releases/download/m3/pets_faster_resnetfpn50.zip"
 
 # Create the same model used in training and load the weights
 # `map_location` will put the model on cpu, optionally move to gpu if necessary

--- a/examples/inference_exp.md
+++ b/examples/inference_exp.md
@@ -18,7 +18,7 @@ class_map = icedata.pets.class_map()
 IMAGE_URL = "https://petcaramelo.com/wp-content/uploads/2018/06/beagle-cachorro.jpg"
 IMG_PATH = "tmp.jpg"
 # Model trained in `Tutorials->Getting Started`
-WEIGHTS_URL = "https://github.com/airctic/model_zoo/releases/download/pets_faster_resnet50fpn/pets_faster_resnetfpn50.zip"
+WEIGHTS_URL = "https://github.com/airctic/model_zoo/releases/download/m3/pets_faster_resnetfpn50.zip"
 
 # Download and open image, optionally show it
 download_url(IMAGE_URL, IMG_PATH)


### PR DESCRIPTION
The GitHub release containing the weights of the pets model from the model zoo has been renamed. This changed the url, which wasn't reflected everywhere in the documentation.

This change updates these outdated urls to point to the updated url.

Fixes #642