### PR TITLE
Allow passing a Config object to the MMDetection models

### DIFF
--- a/icevision/models/mmdet/common/bbox/single_stage/model.py
+++ b/icevision/models/mmdet/common/bbox/single_stage/model.py
@@ -7,11 +7,16 @@ from mmcv.runner import load_checkpoint
 
 
 def model(
-    cfg_path: Union[str, Path],
+    cfg: Union[str, Path, Config],
     num_classes: int,
     weights_path: Optional[Union[str, Path]] = None,
 ) -> nn.Module:
-    cfg = Config.fromfile(str(cfg_path))
+
+    # if `cfg` argument a path (str, Path) create a Config object from the file
+    # otherwise cfg is already a Config object
+    if isinstance(cfg, (str, Path)):
+        cfg = Config.fromfile(str(cfg))
+
     cfg.model.bbox_head.num_classes = num_classes - 1
     if weights_path is not None:
         cfg.model.pretrained = None

--- a/icevision/models/mmdet/common/bbox/single_stage/model.py
+++ b/icevision/models/mmdet/common/bbox/single_stage/model.py
@@ -12,8 +12,8 @@ def model(
     weights_path: Optional[Union[str, Path]] = None,
 ) -> nn.Module:
 
-    # if `cfg` argument a path (str, Path) create a Config object from the file
-    # otherwise cfg is already a Config object
+    # if `cfg` argument is a path (str, Path) create an Config object from the file
+    # otherwise cfg should be already an Config object
     if isinstance(cfg, (str, Path)):
         cfg = Config.fromfile(str(cfg))
 

--- a/icevision/models/mmdet/common/bbox/two_stage/model.py
+++ b/icevision/models/mmdet/common/bbox/two_stage/model.py
@@ -7,11 +7,16 @@ from mmcv.runner import load_checkpoint
 
 
 def model(
-    cfg_path: Union[str, Path],
+    cfg: Union[str, Path, Config],
     num_classes: int,
     weights_path: Optional[Union[str, Path]] = None,
 ) -> nn.Module:
-    cfg = Config.fromfile(str(cfg_path))
+
+    # if `cfg` argument a path (str, Path) create a Config object from the file
+    # otherwise cfg is already a Config object
+    if isinstance(cfg, (str, Path)):
+        cfg = Config.fromfile(str(cfg))
+
     cfg.model.roi_head.bbox_head.num_classes = num_classes - 1
     if weights_path is not None:
         cfg.model.pretrained = None

--- a/icevision/models/mmdet/common/bbox/two_stage/model.py
+++ b/icevision/models/mmdet/common/bbox/two_stage/model.py
@@ -12,8 +12,8 @@ def model(
     weights_path: Optional[Union[str, Path]] = None,
 ) -> nn.Module:
 
-    # if `cfg` argument a path (str, Path) create a Config object from the file
-    # otherwise cfg is already a Config object
+    # if `cfg` argument is a path (str, Path) create an Config object from the file
+    # otherwise cfg should be already an Config object
     if isinstance(cfg, (str, Path)):
         cfg = Config.fromfile(str(cfg))
 

--- a/icevision/models/mmdet/common/mask/two_stage/model.py
+++ b/icevision/models/mmdet/common/mask/two_stage/model.py
@@ -7,11 +7,16 @@ from mmcv.runner import load_checkpoint
 
 
 def model(
-    cfg_path: Union[str, Path],
+    cfg: Union[str, Path, Config],
     num_classes: int,
     weights_path: Optional[Union[str, Path]] = None,
 ) -> nn.Module:
-    cfg = Config.fromfile(str(cfg_path))
+    
+    # if `cfg` argument is a path (str, Path) create an Config object from the file
+    # otherwise cfg should be already an Config object
+    if isinstance(cfg, (str, Path)):
+        cfg = Config.fromfile(str(cfg))
+
     cfg.model.roi_head.bbox_head.num_classes = num_classes - 1
     cfg.model.roi_head.mask_head.num_classes = num_classes - 1
     if weights_path is not None:

--- a/icevision/models/mmdet/common/mask/two_stage/model.py
+++ b/icevision/models/mmdet/common/mask/two_stage/model.py
@@ -11,7 +11,7 @@ def model(
     num_classes: int,
     weights_path: Optional[Union[str, Path]] = None,
 ) -> nn.Module:
-    
+
     # if `cfg` argument is a path (str, Path) create an Config object from the file
     # otherwise cfg should be already an Config object
     if isinstance(cfg, (str, Path)):


### PR DESCRIPTION
I implemented the idea of passing a Config object instead of Config path. I actually added the  Config object option. So, now we can pass either a Config object or Config path: it doesn't break the previous implementation. The users has the option to use one or the other possibility.

Now, we can update the loss_weight(s) for example  (or any Config attribute) like this:

```
cfg = Config.fromfile(cfg_filepath)
cfg.model.bbox_head.loss_cls.loss_weight = 0.8
cfg.model.bbox_head.loss_bbox.loss_weight = 2
```

No need to create/duplicate an external config file and update it

Closes #645 