### PR TITLE
Renamed EfficientDet Backbones

### DIFF
--- a/icevision/models/ross/efficientdet/backbones.py
+++ b/icevision/models/ross/efficientdet/backbones.py
@@ -1,35 +1,35 @@
 __all__ = [
-    "tf_efficientdet_lite0",
-    "efficientdet_d0",
-    "efficientdet_d1",
-    "efficientdet_d2",
-    "efficientdet_d3",
-    "efficientdet_d4",
-    "efficientdet_d5",
-    "efficientdet_d6",
-    "efficientdet_d7",
-    "efficientdet_d7x",
+    "tf_lite0",
+    "d0",
+    "d1",
+    "d2",
+    "d3",
+    "d4",
+    "d5",
+    "d6",
+    "d7",
+    "d7x",
 ]
 
 from icevision.models.ross.efficientdet.utils import *
 
 
-tf_efficientdet_lite0 = EfficientDetBackboneConfig(model_name="tf_efficientdet_lite0")
+tf_lite0 = EfficientDetBackboneConfig(model_name="tf_efficientdet_lite0")
 
-efficientdet_d0 = EfficientDetBackboneConfig(model_name="efficientdet_d0")
+d0 = EfficientDetBackboneConfig(model_name="efficientdet_d0")
 
-efficientdet_d1 = EfficientDetBackboneConfig(model_name="efficientdet_d1")
+d1 = EfficientDetBackboneConfig(model_name="efficientdet_d1")
 
-efficientdet_d2 = EfficientDetBackboneConfig(model_name="efficientdet_d2")
+d2 = EfficientDetBackboneConfig(model_name="efficientdet_d2")
 
-efficientdet_d3 = EfficientDetBackboneConfig(model_name="efficientdet_d3")
+d3 = EfficientDetBackboneConfig(model_name="efficientdet_d3")
 
-efficientdet_d4 = EfficientDetBackboneConfig(model_name="efficientdet_d4")
+d4 = EfficientDetBackboneConfig(model_name="efficientdet_d4")
 
-efficientdet_d5 = EfficientDetBackboneConfig(model_name="efficientdet_d5")
+d5 = EfficientDetBackboneConfig(model_name="efficientdet_d5")
 
-efficientdet_d6 = EfficientDetBackboneConfig(model_name="efficientdet_d6")
+d6 = EfficientDetBackboneConfig(model_name="efficientdet_d6")
 
-efficientdet_d7 = EfficientDetBackboneConfig(model_name="efficientdet_d7")
+d7 = EfficientDetBackboneConfig(model_name="efficientdet_d7")
 
-efficientdet_d7x = EfficientDetBackboneConfig(model_name="efficientdet_d7x")
+d7x = EfficientDetBackboneConfig(model_name="efficientdet_d7x")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,7 @@ def coco_record_id_map():
 def fridge_efficientdet_model() -> nn.Module:
     WEIGHTS_URL = "https://github.com/airctic/model_zoo/releases/download/m2/fridge_tf_efficientdet_lite0.zip"
     # TODO: HACK 5+1 in num_classes (becaues of change in model.py)
-    model = efficientdet.model(
-        backbone=tf_lite0, num_classes=5 + 1, img_size=384
-    )
+    model = efficientdet.model(backbone=tf_lite0, num_classes=5 + 1, img_size=384)
 
     state_dict = torch.hub.load_state_dict_from_url(
         WEIGHTS_URL, map_location=torch.device("cpu")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def fridge_efficientdet_model() -> nn.Module:
     WEIGHTS_URL = "https://github.com/airctic/model_zoo/releases/download/m2/fridge_tf_efficientdet_lite0.zip"
     # TODO: HACK 5+1 in num_classes (becaues of change in model.py)
     model = efficientdet.model(
-        backbone=tf_efficientdet_lite0, num_classes=5 + 1, img_size=384
+        backbone=tf_lite0, num_classes=5 + 1, img_size=384
     )
 
     state_dict = torch.hub.load_state_dict_from_url(

--- a/tests/models/efficient_det/test_model.py
+++ b/tests/models/efficient_det/test_model.py
@@ -6,10 +6,10 @@ from icevision.models.ross.efficientdet.backbones import *
 @pytest.mark.parametrize(
     "backbone",
     [
-        tf_efficientdet_lite0,
-        efficientdet_d0,
-        efficientdet_d1,
-        efficientdet_d2,
+        tf_lite0,
+        d0,
+        d1,
+        d2,
     ],
 )
 def test_efficient_det_param_groups(backbone):


### PR DESCRIPTION
renamed EfficientDet Backbones by deleting the `efficientdet_` part from the names: no need to reference that because the model already suggests that

closes #721 