### PR TITLE
Standardize backbone argument in model method

### DIFF
--- a/icevision/models/torchvision/faster_rcnn/model.py
+++ b/icevision/models/torchvision/faster_rcnn/model.py
@@ -45,7 +45,7 @@ def model(
 
         resnet_fpn.patch_param_groups(model.backbone)
     else:
-        model = FasterRCNN(backbone, num_classes=num_classes, **faster_rcnn_kwargs)
+        model = FasterRCNN(backbone(), num_classes=num_classes, **faster_rcnn_kwargs)
 
     patch_rcnn_param_groups(model=model)
 

--- a/icevision/models/torchvision/keypoint_rcnn/model.py
+++ b/icevision/models/torchvision/keypoint_rcnn/model.py
@@ -57,7 +57,7 @@ def model(
         resnet_fpn.patch_param_groups(model.backbone)
     else:
         model = KeypointRCNN(
-            backbone,
+            backbone(),
             num_classes=num_classes,
             num_keypoints=num_keypoints,
             **keypoint_rcnn_kwargs

--- a/icevision/models/torchvision/mask_rcnn/model.py
+++ b/icevision/models/torchvision/mask_rcnn/model.py
@@ -49,7 +49,7 @@ def model(
 
         resnet_fpn.patch_param_groups(model.backbone)
     else:
-        model = MaskRCNN(backbone, num_classes=num_classes, **mask_rcnn_kwargs)
+        model = MaskRCNN(backbone(), num_classes=num_classes, **mask_rcnn_kwargs)
 
     patch_rcnn_param_groups(model=model)
 

--- a/icevision/models/torchvision/retinanet/model.py
+++ b/icevision/models/torchvision/retinanet/model.py
@@ -30,7 +30,7 @@ def model(
         resnet_fpn.patch_param_groups(model.backbone)
     else:
         model = RetinaNet(
-            backbone=backbone, num_classes=num_classes, **retinanet_kwargs
+            backbone=backbone(), num_classes=num_classes, **retinanet_kwargs
         )
 
     patch_retinanet_param_groups(model)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,8 +33,10 @@ def fridge_efficientdet_model() -> nn.Module:
 
 @pytest.fixture()
 def fridge_faster_rcnn_model() -> nn.Module:
-    backbone = models.torchvision.faster_rcnn.backbones.resnet18_fpn(pretrained=False)
-    return faster_rcnn.model(num_classes=5, backbone=backbone)
+    backbone = icevision.backbones.resnet_fpn.resnet50_fpn
+    return models.torchvision.faster_rcnn.model(
+        num_classes=5, backbone=backbone(pretrained=False)
+    )
 
 
 @pytest.fixture(scope="module")

--- a/tests/models/torchvision_models/mask_rcnn/test_model.py
+++ b/tests/models/torchvision_models/mask_rcnn/test_model.py
@@ -3,15 +3,15 @@ from icevision.models.torchvision import mask_rcnn
 
 
 def test_mask_rcnn_default_param_groups():
-    model = mask_rcnn.model(num_classes=4)
+    model = models.torchvision.mask_rcnn.model(num_classes=4)
 
     param_groups = model.param_groups()
     assert len(param_groups) == 8
 
 
 def test_mask_rcnn_mobile_param_groups():
-    backbone = backbones.mobilenet(pretrained=False)
-    model = mask_rcnn.model(num_classes=6, backbone=backbone)
+    backbone = backbones.mobilenet
+    model = models.torchvision.mask_rcnn.model(num_classes=6, backbone=backbone(pretrained=False))
 
     param_groups = model.param_groups()
     assert len(param_groups) == 6


### PR DESCRIPTION
Backbones are passed as methods. the torchvision `model()` method expect a nn.Module. Therefore, the `backbone` argument is now called when passed to the `model()` method.

closes #727 