### PR TITLE
move the _unload method

### DIFF
--- a/icevision/core/record_components.py
+++ b/icevision/core/record_components.py
@@ -130,6 +130,9 @@ class ImageRecordComponent(RecordComponent):
         else:
             return [f"Image: {self.img}"]
 
+    def _unload(self):
+        self.img = None
+
     def as_dict(self) -> dict:
         return {"img": self.img}
 
@@ -148,9 +151,6 @@ class FilepathRecordComponent(ImageRecordComponent):
     def _load(self):
         img = open_img(self.filepath)
         self.set_img(img)
-
-    def _unload(self):
-        self.img = None
 
     def _autofix(self) -> Dict[str, bool]:
         exists = self.filepath.exists()


### PR DESCRIPTION
 from FilepathRecordComponent to ImageRecordComponent to avoid memory leak when the latter exists without the first