### PR TITLE
Add record unloading & refactor common_build_batch

### DIFF
--- a/icevision/models/interpretation.py
+++ b/icevision/models/interpretation.py
@@ -216,7 +216,6 @@ class Interpretation:
             f"Losses returned by model: {[l for l in list(_prepend_str(self.losses_dict, 'loss').keys()) if l!='loss_total']}",
         )
 
-        dl = self.valid_dl(dataset, batch_size=1, num_workers=0, shuffle=False)
         samples, losses_stats = self.get_losses(model, dataset)
         samples = add_annotations(samples)
 
@@ -236,14 +235,19 @@ class Interpretation:
             ann2 = "\n".join(ann[4:])
             anns.append((ann1, ann2))
 
+        # reload only the displayed images
+        displayed_preds = [
+            Prediction(pred=p, ground_truth=s.load())
+            for s, p in zip(sorted_samples[:n_samples], sorted_preds[:n_samples])
+        ]
+
         sorted_preds = [
             Prediction(pred=p, ground_truth=s)
             for s, p in zip(sorted_samples, sorted_preds)
         ]
 
         show_preds(
-            preds=sorted_preds[:n_samples],
-            annotations=anns[:n_samples],
+            preds=displayed_preds, annotations=anns[:n_samples], denormalize_fn=None
         )
         model.train()
         return sorted_samples, sorted_preds, losses_stats

--- a/icevision/models/mmdet/common/bbox/dataloaders.py
+++ b/icevision/models/mmdet/common/bbox/dataloaders.py
@@ -51,10 +51,8 @@ def infer_dl(dataset, batch_tfms=None, **dataloader_kwargs) -> DataLoader:
 
 
 def build_train_batch(
-    records: Sequence[RecordType], batch_tfms=None
+    records: Sequence[RecordType],
 ) -> Tuple[dict, List[Dict[str, torch.Tensor]]]:
-    records = common_build_batch(records=records, batch_tfms=batch_tfms)
-
     images, labels, bboxes, img_metas = [], [], [], []
     for record in records:
         images.append(_img_tensor(record))
@@ -73,14 +71,12 @@ def build_train_batch(
 
 
 def build_valid_batch(
-    records: Sequence[RecordType], batch_tfms=None
+    records: Sequence[RecordType],
 ) -> Tuple[dict, List[Dict[str, torch.Tensor]]]:
-    return build_train_batch(records=records, batch_tfms=batch_tfms)
+    return build_train_batch(records=records)
 
 
-def build_infer_batch(records, batch_tfms=None):
-    records = common_build_batch(records, batch_tfms=batch_tfms)
-
+def build_infer_batch(records):
     imgs, img_metas = [], []
     for record in records:
         imgs.append(_img_tensor(record))

--- a/icevision/models/mmdet/common/mask/dataloaders.py
+++ b/icevision/models/mmdet/common/mask/dataloaders.py
@@ -58,16 +58,14 @@ def infer_dl(dataset, batch_tfms=None, **dataloader_kwargs) -> DataLoader:
 
 
 def build_valid_batch(
-    records: Sequence[RecordType], batch_tfms=None
+    records: Sequence[RecordType],
 ) -> Tuple[dict, List[Dict[str, torch.Tensor]]]:
-    return build_train_batch(records=records, batch_tfms=batch_tfms)
+    return build_train_batch(records=records)
 
 
 def build_train_batch(
-    records: Sequence[RecordType], batch_tfms=None
+    records: Sequence[RecordType],
 ) -> Tuple[dict, List[Dict[str, torch.Tensor]]]:
-    records = common_build_batch(records=records, batch_tfms=batch_tfms)
-
     images, labels, bboxes, masks, img_metas = [], [], [], [], []
     for record in records:
         images.append(_img_tensor(record))
@@ -87,9 +85,7 @@ def build_train_batch(
     return data, records
 
 
-def build_infer_batch(records, batch_tfms=None):
-    records = common_build_batch(records, batch_tfms=batch_tfms)
-
+def build_infer_batch(records):
     imgs, img_metas = [], []
     for record in records:
         imgs.append(_img_tensor(record))

--- a/icevision/models/ross/efficientdet/dataloaders.py
+++ b/icevision/models/ross/efficientdet/dataloaders.py
@@ -71,17 +71,16 @@ def infer_dl(dataset, batch_tfms=None, **dataloader_kwargs) -> DataLoader:
     )
 
 
-def build_train_batch(records, batch_tfms=None):
+def build_train_batch(records):
     """Builds a batch in the format required by the model when training.
 
     # Arguments
         records: A `Sequence` of records.
-        batch_tfms: Transforms to be applied at the batch level.
 
     # Returns
         A tuple with two items. The first will be a tuple like `(images, targets)`,
-        in the input format required by the model. The second will be an updated list
-        of the input records with `batch_tfms` applied.
+        in the input format required by the model. The second will be a list
+        of the input records.
 
     # Examples
 
@@ -91,7 +90,6 @@ def build_train_batch(records, batch_tfms=None):
     outs = model(*batch)
     ```
     """
-    records = common_build_batch(records, batch_tfms=batch_tfms)
     batch_images, batch_bboxes, batch_classes = zip(
         *(process_train_record(record) for record in records)
     )
@@ -107,17 +105,16 @@ def build_train_batch(records, batch_tfms=None):
     return (batch_images, targets), records
 
 
-def build_valid_batch(records, batch_tfms=None):
+def build_valid_batch(records):
     """Builds a batch in the format required by the model when validating.
 
     # Arguments
         records: A `Sequence` of records.
-        batch_tfms: Transforms to be applied at the batch level.
 
     # Returns
-        A tuple with two items. The first will be a tuple like `(batch_images, targets)`,
-        in the input format required by the model. The second will be an updated list
-        of the input records with `batch_tfms` applied.
+        A tuple with two items. The first will be a tuple like `(images, targets)`,
+        in the input format required by the model. The second will be a list
+        of the input records.
 
     # Examples
 
@@ -127,7 +124,7 @@ def build_valid_batch(records, batch_tfms=None):
     outs = model(*batch)
     ```
     """
-    (batch_images, targets), records = build_train_batch(records, batch_tfms)
+    (batch_images, targets), records = build_train_batch(records)
 
     # convert to EffDet interface, when not training, dummy size and scale is required
     targets = dict(img_size=None, img_scale=None, **targets)
@@ -135,24 +132,22 @@ def build_valid_batch(records, batch_tfms=None):
     return (batch_images, targets), records
 
 
-def build_infer_batch(records, batch_tfms=None):
+def build_infer_batch(records):
     """Builds a batch in the format required by the model when doing inference.
 
     # Arguments
         records: A `Sequence` of records.
-        batch_tfms: Transforms to be applied at the batch level.
 
     # Returns
         A tuple with two items. The first will be a tuple like `(images, targets)`,
-        in the input format required by the model. The second will be an updated list
-        of the input records with `batch_tfms` applied. # Examples
+        in the input format required by the model. The second will be a list
+        of the input records.
     Use the result of this function to feed the model.
     ```python
     batch, records = build_infer_batch(records)
     outs = model(*batch)
     ```
     """
-    records = common_build_batch(records, batch_tfms=batch_tfms)
     batch_images, batch_sizes, batch_scales = zip(
         *(process_infer_record(record) for record in records)
     )

--- a/icevision/models/torchvision/faster_rcnn/dataloaders.py
+++ b/icevision/models/torchvision/faster_rcnn/dataloaders.py
@@ -149,7 +149,7 @@ def build_valid_batch(
     return build_train_batch(records=records)
 
 
-def build_infer_batch(dataset: Sequence[RecordType]):
+def build_infer_batch(records: Sequence[RecordType]):
     """Builds a batch in the format required by the model when doing inference.
 
     # Arguments
@@ -168,7 +168,7 @@ def build_infer_batch(dataset: Sequence[RecordType]):
     outs = model(*batch)
     ```
     """
-    tensor_imgs = [im2tensor(sample.img) for sample in dataset]
+    tensor_imgs = [im2tensor(record.img) for record in records]
     tensor_imgs = torch.stack(tensor_imgs)
 
-    return (tensor_imgs,), dataset
+    return (tensor_imgs,), records

--- a/icevision/models/torchvision/faster_rcnn/dataloaders.py
+++ b/icevision/models/torchvision/faster_rcnn/dataloaders.py
@@ -94,7 +94,7 @@ def _build_train_sample(
 
 
 def build_train_batch(
-    records: Sequence[RecordType], batch_tfms=None
+    records: Sequence[RecordType],
 ) -> Tuple[List[torch.Tensor], List[Dict[str, torch.Tensor]]]:
     """Builds a batch in the format required by the model when training.
 
@@ -104,8 +104,8 @@ def build_train_batch(
 
     # Returns
         A tuple with two items. The first will be a tuple like `(images, targets)`,
-        in the input format required by the model. The second will be an updated list
-        of the input records with `batch_tfms` applied.
+        in the input format required by the model. The second will be a list
+        of the input records.
 
     # Examples
 
@@ -115,8 +115,6 @@ def build_train_batch(
     outs = model(*batch)
     ```
     """
-    records = common_build_batch(records=records, batch_tfms=batch_tfms)
-
     images, targets = [], []
     for record in records:
         image, target = _build_train_sample(record)
@@ -127,7 +125,7 @@ def build_train_batch(
 
 
 def build_valid_batch(
-    records: List[RecordType], batch_tfms=None
+    records: List[RecordType],
 ) -> Tuple[List[torch.Tensor], Dict[str, torch.Tensor]]:
     """Builds a batch in the format required by the model when validating.
 
@@ -137,8 +135,8 @@ def build_valid_batch(
 
     # Returns
         A tuple with two items. The first will be a tuple like `(images, targets)`,
-        in the input format required by the model. The second will be an updated list
-        of the input records with `batch_tfms` applied.
+        in the input format required by the model. The second will be a list
+        of the input records.
 
     # Examples
 
@@ -148,20 +146,19 @@ def build_valid_batch(
     outs = model(*batch)
     ```
     """
-    return build_train_batch(records=records, batch_tfms=batch_tfms)
+    return build_train_batch(records=records)
 
 
-def build_infer_batch(dataset: Sequence[RecordType], batch_tfms=None):
+def build_infer_batch(dataset: Sequence[RecordType]):
     """Builds a batch in the format required by the model when doing inference.
 
     # Arguments
         records: A `Sequence` of records.
-        batch_tfms: Transforms to be applied at the batch level.
 
     # Returns
         A tuple with two items. The first will be a tuple like `(images, targets)`,
-        in the input format required by the model. The second will be an updated list
-        of the input records with `batch_tfms` applied.
+        in the input format required by the model. The second will be a list
+        of the input records.
 
     # Examples
 
@@ -171,9 +168,7 @@ def build_infer_batch(dataset: Sequence[RecordType], batch_tfms=None):
     outs = model(*batch)
     ```
     """
-    samples = common_build_batch(dataset, batch_tfms=batch_tfms)
-
-    tensor_imgs = [im2tensor(sample.img) for sample in samples]
+    tensor_imgs = [im2tensor(sample.img) for sample in dataset]
     tensor_imgs = torch.stack(tensor_imgs)
 
-    return (tensor_imgs,), samples
+    return (tensor_imgs,), dataset

--- a/icevision/models/torchvision/keypoint_rcnn/dataloaders.py
+++ b/icevision/models/torchvision/keypoint_rcnn/dataloaders.py
@@ -80,7 +80,7 @@ def _build_keypoints_train_sample(record: RecordType):
 
 
 def build_train_batch(
-    records: List[RecordType], batch_tfms=None
+    records: List[RecordType],
 ) -> Tuple[List[torch.Tensor], List[Dict[str, torch.Tensor]]]:
     """Builds a batch in the format required by the model when training.
 
@@ -90,8 +90,8 @@ def build_train_batch(
 
     # Returns
         A tuple with two items. The first will be a tuple like `(images, targets)`,
-        in the input format required by the model. The second will be an updated list
-        of the input records with `batch_tfms` applied.
+        in the input format required by the model. The second will be a list
+        of the input records.
 
     # Examples
 
@@ -101,8 +101,6 @@ def build_train_batch(
     outs = model(*batch)
     ```
     """
-    records = common_build_batch(records)
-
     images, targets = [], []
     for record in records:
         image, target = _build_keypoints_train_sample(record)
@@ -113,7 +111,7 @@ def build_train_batch(
 
 
 def build_valid_batch(
-    records: List[RecordType], batch_tfms=None
+    records: List[RecordType],
 ) -> Tuple[List[torch.Tensor], List[Dict[str, torch.Tensor]]]:
     """Builds a batch in the format required by the model when validating.
 
@@ -123,8 +121,8 @@ def build_valid_batch(
 
     # Returns
         A tuple with two items. The first will be a tuple like `(images, targets)`,
-        in the input format required by the model. The second will be an updated list
-        of the input records with `batch_tfms` applied.
+        in the input format required by the model. The second will be a list
+        of the input records.
 
     # Examples
 

--- a/icevision/models/torchvision/mask_rcnn/dataloaders.py
+++ b/icevision/models/torchvision/mask_rcnn/dataloaders.py
@@ -80,7 +80,7 @@ def _build_mask_train_sample(record: RecordType):
 
 
 def build_train_batch(
-    records: List[RecordType], batch_tfms=None
+    records: List[RecordType],
 ) -> Tuple[List[torch.Tensor], List[Dict[str, torch.Tensor]]]:
     """Builds a batch in the format required by the model when training.
 
@@ -90,8 +90,8 @@ def build_train_batch(
 
     # Returns
         A tuple with two items. The first will be a tuple like `(images, targets)`,
-        in the input format required by the model. The second will be an updated list
-        of the input records with `batch_tfms` applied.
+        in the input format required by the model. The second will be a list
+        of the input records.
 
     # Examples
 
@@ -101,8 +101,6 @@ def build_train_batch(
     outs = model(*batch)
     ```
     """
-    records = common_build_batch(records)
-
     images, targets = [], []
     for record in records:
         image, target = _build_mask_train_sample(record)
@@ -113,7 +111,7 @@ def build_train_batch(
 
 
 def build_valid_batch(
-    records: List[RecordType], batch_tfms=None
+    records: List[RecordType],
 ) -> Tuple[List[torch.Tensor], List[Dict[str, torch.Tensor]]]:
     """Builds a batch in the format required by the model when validating.
 
@@ -123,8 +121,8 @@ def build_valid_batch(
 
     # Returns
         A tuple with two items. The first will be a tuple like `(images, targets)`,
-        in the input format required by the model. The second will be an updated list
-        of the input records with `batch_tfms` applied.
+        in the input format required by the model. The second will be a list
+        of the input records.
 
     # Examples
 

--- a/icevision/models/utils.py
+++ b/icevision/models/utils.py
@@ -74,10 +74,10 @@ def unload_records(build_batch):
     """This decorator function unloads records to not carry them around after batch creation"""
 
     def inner(records):
-        (batch_images, targets), records = build_batch(records)
+        tupled_output, records = build_batch(records)
         for record in records:
             record.unload()
-        return (batch_images, targets), records
+        return tupled_output, records
 
     return inner
 


### PR DESCRIPTION
Implemented the discussed changes, mitigates the excessive leak discussed in https://github.com/airctic/icevision/issues/692

1. Unload records is a decorator of `collate_fn`, which is now put in `transform_dl`.
2. `apply_batch_tfms` (previously `common_build_batch`) is now a decorator function that is run on top of each `build_batch` function that we define within dataloaders. It is used in a single place so no repetition takes place and works in the same pattern as before. 
3. Changed plot_top_losses to reaload the now unloaded ground_truth images
3. Also fixed some smaller bugs like in icevision/models/torchvision/keypoint_rcnn/dataloaders.py@104 where the tfms were not passed at all.
4. Renamed samples or dataset to records in torchvision dataloaders for consistency.
5. Updated the docs