### PR TITLE
Doc site versioning, issue #715

### DIFF
--- a/.github/workflows/mk-docs-build.yml
+++ b/.github/workflows/mk-docs-build.yml
@@ -5,6 +5,11 @@ on:
     branches: [ master ]
   push:
     branches: [ master ]
+  release:
+    types: [ created ]    
+
+env:
+  SITE_BRANCH: ${{ 'gh-pages-ver' }}
 
 jobs:
   build:
@@ -12,11 +17,13 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install package
         run: |
@@ -24,13 +31,47 @@ jobs:
           pip install mmcv-full=="1.2.5+torch.1.7.0+cpu" -f https://download.openmmlab.com/mmcv/dist/index.html --use-deprecated=legacy-resolver
           pip install mmdet
           pip install -e ".[all,dev]"
+          # Below version is needed to work around a clash with ruamel-yaml. When v1.0 is released this can be removed.
+          pip install git+git://github.com/jimporter/mike.git@2961733cbfef132e9d63752307443981ad02d1fc --upgrade
 
-      - name: Build the docs
+      - name: Prepare the docs
         run:  |
           cd docs
           python autogen.py
-          mkdocs build
 
-      - name: Deploy docs (if pushing to master)
+      - name: Setup git config
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "bot@airctic.com"
+
+      - name: Build the docs locally only
+        if: github.event_name == 'pull_request'
+        run:  |
+          mike deploy dev -b ${{ env.SITE_BRANCH }} 
+
+      - name: Deploy dev docs
+        id: deploy_dev
         if: github.repository == 'airctic/icevision' && github.event_name == 'push'
-        run: cd docs && mkdocs gh-deploy --force
+        run: |
+          mike deploy dev -b ${{ env.SITE_BRANCH }} -p
+          echo '::set-output name=MIKE_VERSIONS::'$(mike list -b ${{ env.SITE_BRANCH }} | wc -l)     
+
+      - name: Set dev as default
+        if: steps.deploy_dev.outputs.MIKE_VERSIONS == 1
+        run: |
+          mike set-default -b ${{ env.SITE_BRANCH }} dev -p
+
+      - name: Get latest release tag
+        if: github.event_name == 'release'
+        id: latest
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          excludes: prerelease
+          repository: ${{ github.repository }}
+
+      - name: Release docs
+        if: github.event_name == 'release'
+        run: |
+          echo Deploy as ${{ steps.latest.outputs.release }} 
+          mike deploy -b ${{ env.SITE_BRANCH }} ${{ steps.latest.outputs.release }} -p
+          mike set-default -b ${{ env.SITE_BRANCH }} ${{ steps.latest.outputs.release }} -p     

--- a/.github/workflows/mk-docs-build.yml
+++ b/.github/workflows/mk-docs-build.yml
@@ -47,18 +47,21 @@ jobs:
       - name: Build the docs locally only
         if: github.event_name == 'pull_request'
         run:  |
+          cd docs
           mike deploy dev -b ${{ env.SITE_BRANCH }} 
 
       - name: Deploy dev docs
         id: deploy_dev
         if: github.repository == 'airctic/icevision' && github.event_name == 'push'
         run: |
+          cd docs
           mike deploy dev -b ${{ env.SITE_BRANCH }} -p
           echo '::set-output name=MIKE_VERSIONS::'$(mike list -b ${{ env.SITE_BRANCH }} | wc -l)     
 
       - name: Set dev as default
         if: steps.deploy_dev.outputs.MIKE_VERSIONS == 1
         run: |
+          cd docs
           mike set-default -b ${{ env.SITE_BRANCH }} dev -p
 
       - name: Get latest release tag
@@ -72,6 +75,7 @@ jobs:
       - name: Release docs
         if: github.event_name == 'release'
         run: |
+          cd docs
           echo Deploy as ${{ steps.latest.outputs.release }} 
           mike deploy -b ${{ env.SITE_BRANCH }} ${{ steps.latest.outputs.release }} -p
           mike set-default -b ${{ env.SITE_BRANCH }} ${{ steps.latest.outputs.release }} -p     

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -40,7 +40,10 @@ extra_javascript:
 - js/custom.js
 - https://cdn.jsdelivr.net/npm/@widgetbot/crate@3
 - js/crate.js
-
+extra:
+  version:
+    provider: mike
+    
 nav:
   - Home: index.md
   - Installation: install.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,8 @@ dev =
   pytest >=6,<7
   keras-autodoc ==0.6.0
   mkdocs >=1.1.2,<2
-  mkdocs-material >=5.5.12,<6
+  mkdocs-material >=7.0.6,<8
+  mike >=0.5.5,<1
   jupyter >=1.0.0,<2
   pymdown-extensions >=8.0,<9
   Sphinx >=3.1.0,<4


### PR DESCRIPTION
This PR adds documentation site versioning using an updated mkdocs-material and [mike](https://github.com/jimporter/mike). The mike concept is to align your documentation with your releases and not to go back and edit a released version. Mike and the automation in this PR is in line with the IceVision release pattern of a single mainline based development and release process; all releases are sourced from the trunk.

Pull-requests, pushes and releases are all covered in this single action:

- `pull_request` - deploy the docs locally only in order to expose any errors
- `push` - deploy the docs as `dev` and push to the site branch
- `release` - find the latest release version, deploy the docs as that version and push to the site branch

The site branch is configurable through the env in the action. This allows for the docs to be pushed to a different branch than the live `gh-pages`. This is a contingency in case something goes wrong in the early days of this new documentation so we can easily switch which branch is published to the web. 