### PR TITLE
Update Dataset to pass the model's class map to show_preds and display the string labels in the prediction results

### DIFF
--- a/icevision/data/dataset.py
+++ b/icevision/data/dataset.py
@@ -41,7 +41,7 @@ class Dataset:
         return f"<{self.__class__.__name__} with {len(self.records)} items>"
 
     @classmethod
-    def from_images(cls, images: Sequence[np.array], tfm: Transform = None):
+    def from_images(cls, images: Sequence[np.array], tfm: Transform = None, class_map: ClassMap = None):
         """Creates a `Dataset` from a list of images.
 
         # Arguments
@@ -57,5 +57,6 @@ class Dataset:
 
             # TODO, HACK: adding class map because of `convert_raw_prediction`
             record.add_component(ClassMapRecordComponent(task=tasks.detection))
+            record.detection.set_class_map(class_map)
 
         return cls(records=records, tfm=tfm)


### PR DESCRIPTION
This enables passing the model's class labels to an image dataset when invoking:  dataset.from_images 
and to display the labels along with the BBoxes when running inference with show_pred.
Method:  
infer_neg_ds = Dataset.from_images([img], tfms, class_map=class_map)
show_preds(preds=preds[:6], class_map = class_map,denormalize_fn=denormalize_imagenet,ncols=3,)

