### PR TITLE
adding extra_large yoloV5 backbone

### DIFF
--- a/icevision/models/ultralytics/yolov5/backbones.py
+++ b/icevision/models/ultralytics/yolov5/backbones.py
@@ -2,6 +2,7 @@ __all__ = [
     "small",
     "medium",
     "large",
+    "extra_large",
 ]
 
 from icevision.models.ultralytics.yolov5.utils import *
@@ -12,3 +13,5 @@ small = YoloV5BackboneConfig(model_name="yolov5s")
 medium = YoloV5BackboneConfig(model_name="yolov5m")
 
 large = YoloV5BackboneConfig(model_name="yolov5l")
+
+extra_large = YoloV5BackboneConfig(model_name="yolov5x")

--- a/tests/models/ultralytics/yolov5/fastai/test_train.py
+++ b/tests/models/ultralytics/yolov5/fastai/test_train.py
@@ -5,7 +5,7 @@ from icevision.models.ultralytics.yolov5.backbones import *
 
 @pytest.mark.parametrize(
     "backbone",
-    [small, medium, large],
+    [small, medium, large, extra_large],
 )
 def test_fastai_yolo_train(fridge_ds, backbone):
     train_ds, valid_ds = fridge_ds

--- a/tests/models/ultralytics/yolov5/lightning/test_train.py
+++ b/tests/models/ultralytics/yolov5/lightning/test_train.py
@@ -5,7 +5,7 @@ from icevision.models.ultralytics.yolov5.backbones import *
 
 @pytest.mark.parametrize(
     "backbone",
-    [small, medium, large],
+    [small, medium, large, extra_large],
 )
 def test_lightning_yolo_train(fridge_ds, backbone):
     train_ds, valid_ds = fridge_ds

--- a/tests/models/ultralytics/yolov5/test_model.py
+++ b/tests/models/ultralytics/yolov5/test_model.py
@@ -5,7 +5,7 @@ from icevision.models.ultralytics.yolov5.backbones import *
 
 @pytest.mark.parametrize(
     "backbone",
-    [small, medium, large],
+    [small, medium, large, extra_large],
 )
 def test_yolo_model(backbone):
     model = models.ultralytics.yolov5.model(
@@ -20,7 +20,7 @@ def test_yolo_model(backbone):
 
 @pytest.mark.parametrize(
     "backbone",
-    [small, medium, large],
+    [small, medium, large, extra_large],
 )
 def test_yolo_model_notpretrained(backbone):
     model = models.ultralytics.yolov5.model(

--- a/tests/models/ultralytics/yolov5/test_prediction.py
+++ b/tests/models/ultralytics/yolov5/test_prediction.py
@@ -12,7 +12,7 @@ def _test_preds(preds):
 
 @pytest.mark.parametrize(
     "backbone",
-    [small, medium, large],
+    [small, medium, large, extra_large],
 )
 def test_yolo_predict(fridge_ds, backbone):
     _, valid_ds = fridge_ds
@@ -25,7 +25,7 @@ def test_yolo_predict(fridge_ds, backbone):
 
 @pytest.mark.parametrize(
     "backbone",
-    [small, medium, large],
+    [small, medium, large, extra_large],
 )
 def test_yolo_predict_from_dl(fridge_ds, backbone):
     _, valid_ds = fridge_ds

--- a/tests/models/ultralytics/yolov5/test_show_results.py
+++ b/tests/models/ultralytics/yolov5/test_show_results.py
@@ -5,7 +5,7 @@ from icevision.models.ultralytics.yolov5.backbones import *
 
 @pytest.mark.parametrize(
     "backbone",
-    [small, medium, large],
+    [small, medium, large, extra_large],
 )
 def test_show_results(fridge_ds, backbone, monkeypatch):
     monkeypatch.setattr(plt, "show", lambda: None)
@@ -18,7 +18,7 @@ def test_show_results(fridge_ds, backbone, monkeypatch):
 
 @pytest.mark.parametrize(
     "backbone",
-    [small, medium, large],
+    [small, medium, large, extra_large],
 )
 def test_plot_losses(fridge_ds, backbone, monkeypatch):
     monkeypatch.setattr(plt, "show", lambda: None)


### PR DESCRIPTION
I realized YOLOv5 supports a 4th backbone, the `extra_large` one.
Not sure why I didn't notice that in the first place.