### PR TITLE
Add PIL Image Compatibility with Record Components

### DIFF
--- a/icevision/core/record_components.py
+++ b/icevision/core/record_components.py
@@ -152,16 +152,15 @@ class ImageRecordComponent(RecordComponent):
 
 
 class FilepathRecordComponent(ImageRecordComponent):
-    def __init__(self, task=tasks.common, as_array=True):
+    def __init__(self, task=tasks.common):
         super().__init__(task=task)
         self.filepath = None
-        self.as_array = as_array
 
     def set_filepath(self, filepath: Union[str, Path]):
         self.filepath = Path(filepath)
 
     def _load(self):
-        img = open_img(self.filepath, as_array=self.as_array)
+        img = open_img(self.filepath)
         self.set_img(img)
 
     def _autofix(self) -> Dict[str, bool]:

--- a/icevision/core/record_components.py
+++ b/icevision/core/record_components.py
@@ -111,10 +111,10 @@ class ImageRecordComponent(RecordComponent):
         super().__init__(task=task)
         self.img = None
 
-    def set_img(self, img: Union[Image.Image, np.ndarray]):
-        assert isinstance(img, (Image.Image, np.ndarray))
+    def set_img(self, img: Union[PIL.Image.Image, np.ndarray]):
+        assert isinstance(img, (PIL.Image.Image, np.ndarray))
         self.img = img
-        if isinstance(img, Image.Image):
+        if isinstance(img, PIL.Image.Image):
             height, width = img.shape
         elif isinstance(img, np.ndarray):
             # else:
@@ -133,7 +133,9 @@ class ImageRecordComponent(RecordComponent):
                 raise ValueError(
                     f"Expected image to have 2 or 3 dimensions, got {ndims} instead"
                 )
-            _type = "PIL.Image" if isinstance(self.img, Image.Image) else "np.ndarray"
+            _type = (
+                "PIL.Image" if isinstance(self.img, PIL.Image.Image) else "np.ndarray"
+            )
             return [f"Image: {width}x{height}x{channels} <{_type}> Image"]
         else:
             return [f"Image: {self.img}"]

--- a/icevision/core/record_components.py
+++ b/icevision/core/record_components.py
@@ -99,7 +99,7 @@ class RecordIDRecordComponent(RecordComponent):
         self.record_id = record_id
 
     def _repr(self) -> List[str]:
-        return [f"Image ID: {self.record_id}"]
+        return [f"Record ID: {self.record_id}"]
 
     def as_dict(self) -> dict:
         return {"record_id": self.record_id}
@@ -134,12 +134,12 @@ class ImageRecordComponent(RecordComponent):
                     raise ValueError(
                         f"Expected image to have 2 or 3 dimensions, got {ndims} instead"
                     )
-                return [f"Image: {width}x{height}x{channels} <np.ndarray> Image"]
+                return [f"Img: {width}x{height}x{channels} <np.ndarray> Image"]
             elif isinstance(self.img, PIL.Image.Image):
                 height, width = self.img.shape
-                return [f"Image: {width}x{height} <PIL.Image; mode='{self.img.mode}'>"]
+                return [f"Img: {width}x{height} <PIL.Image; mode='{self.img.mode}'>"]
         else:
-            return [f"Image: {self.img}"]
+            return [f"Img: {self.img}"]
 
     def _unload(self):
         self.img = None

--- a/icevision/core/record_components.py
+++ b/icevision/core/record_components.py
@@ -124,19 +124,20 @@ class ImageRecordComponent(RecordComponent):
 
     def _repr(self) -> List[str]:
         if self.img is not None:
-            ndims = len(self.img.shape)
-            if ndims == 3:  # RGB, RGBA
-                height, width, channels = self.img.shape
-            elif ndims == 2:  # Grayscale
-                height, width, channels = [*self.img.shape, 1]
-            else:
-                raise ValueError(
-                    f"Expected image to have 2 or 3 dimensions, got {ndims} instead"
-                )
-            _type = (
-                "PIL.Image" if isinstance(self.img, PIL.Image.Image) else "np.ndarray"
-            )
-            return [f"Image: {width}x{height}x{channels} <{_type}> Image"]
+            if isinstance(self.img, np.ndarray):
+                ndims = len(self.img.shape)
+                if ndims == 3:  # RGB, RGBA
+                    height, width, channels = self.img.shape
+                elif ndims == 2:  # Grayscale
+                    height, width, channels = [*self.img.shape, 1]
+                else:
+                    raise ValueError(
+                        f"Expected image to have 2 or 3 dimensions, got {ndims} instead"
+                    )
+                return [f"Image: {width}x{height}x{channels} <np.ndarray> Image"]
+            elif isinstance(self.img, PIL.Image.Image):
+                height, width = self.img.shape
+                return [f"Image: {width}x{height} <PIL.Image; mode='{self.img.mode}'>"]
         else:
             return [f"Image: {self.img}"]
 

--- a/icevision/data/dataset.py
+++ b/icevision/data/dataset.py
@@ -35,6 +35,9 @@ class Dataset:
         record = self.records[i].load()
         if self.tfm is not None:
             record = self.tfm(record)
+        else:
+            # HACK FIXME
+            record.set_img(np.array(record.img))
         return record
 
     def __repr__(self):

--- a/icevision/tfms/albumentations/albumentations_adapter.py
+++ b/icevision/tfms/albumentations/albumentations_adapter.py
@@ -42,7 +42,8 @@ class AlbumentationsAdapterComponent(Component):
 
 class AlbumentationsImgComponent(AlbumentationsAdapterComponent):
     def setup_img(self, record):
-        self.adapter._albu_in["image"] = record.img
+        # NOTE - assumed that `record.img` is a PIL.Image
+        self.adapter._albu_in["image"] = np.array(record.img)
 
         self.adapter._collect_ops.append(CollectOp(self.collect))
 

--- a/icevision/tfms/albumentations/albumentations_adapter.py
+++ b/icevision/tfms/albumentations/albumentations_adapter.py
@@ -299,7 +299,7 @@ class Adapter(Transform, Composite):
         height, width, _ = self._albu_out["image"].shape
 
         if get_transform(self.tfms_list, "Pad") is not None:
-            after_pad_h, after_pad_w, _ = record.img.shape
+            after_pad_h, after_pad_w, _ = np.array(record.img).shape
 
             t = get_transform(self.tfms_list, "SmallestMaxSize")
             if t is not None:

--- a/icevision/utils/imageio.py
+++ b/icevision/utils/imageio.py
@@ -18,12 +18,14 @@ for _EXIF_ORIENTATION_TAG in ExifTags.TAGS.keys():
         break
 
 
-def open_img(fn, gray=False):
+def open_img(fn, gray=False, as_array=True):
     color = "L" if gray else "RGB"
     image = PIL.Image.open(str(fn))
     image = PIL.ImageOps.exif_transpose(image)
     image = image.convert(color)
-    return np.array(image)
+    if as_array:
+        return np.array(image)
+    return image
 
 
 # TODO: Deprecated

--- a/icevision/utils/imageio.py
+++ b/icevision/utils/imageio.py
@@ -17,14 +17,18 @@ for _EXIF_ORIENTATION_TAG in ExifTags.TAGS.keys():
     if PIL.ExifTags.TAGS[_EXIF_ORIENTATION_TAG] == "Orientation":
         break
 
+# from enum import Enum
 
-def open_img(fn, gray=False, as_array=True):
+# class PILMode(Enum):
+#     blah
+
+# FIXME
+def open_img(fn, gray=False) -> PIL.Image.Image:
+    "Open an image from disk `fn` as a PIL Image"
     color = "L" if gray else "RGB"
     image = PIL.Image.open(str(fn))
     image = PIL.ImageOps.exif_transpose(image)
     image = image.convert(color)
-    if as_array:
-        return np.array(image)
     return image
 
 

--- a/icevision/visualize/draw_data.py
+++ b/icevision/visualize/draw_data.py
@@ -74,7 +74,7 @@ def draw_sample(
     * include_only: (Optional) List of labels that must be exclusively plotted. Takes
                     precedence over `exclude_labels` (?)
     """
-    img = sample.img.copy()
+    img = np.asarray(sample.img).copy()  # HACK
     num_classification_plotted = 0
 
     # Dynamic font size based on image height

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -70,7 +70,7 @@ def record_wrong_num_annotations(samples_source):
 def test_record_load(record):
     record_loaded = record.load()
 
-    assert isinstance(record_loaded.img, np.ndarray)
+    assert isinstance(record_loaded.img, PIL.Image.Image)
     assert isinstance(record_loaded.detection.masks, MaskArray)
 
     # test original record is not modified

--- a/tests/models/torchvision_models/mask_rcnn/test_predict.py
+++ b/tests/models/torchvision_models/mask_rcnn/test_predict.py
@@ -9,7 +9,7 @@ def sample_dataset(samples_source):
     images_dir = samples_source / "images"
     images_files = get_image_files(images_dir)[-2:]
 
-    images = [open_img(path) for path in images_files]
+    images = [np.array(open_img(path)) for path in images_files]
     images = [cv2.resize(image, (128, 128)) for image in images]
 
     return Dataset.from_images(images)

--- a/tests/transforms/test_albu_transform.py
+++ b/tests/transforms/test_albu_transform.py
@@ -24,7 +24,7 @@ def test_inference_transform(records, check_attributes_on_component):
     ds = Dataset.from_images([img], tfm)
 
     tfmed = ds[0]
-    assert (tfmed.img == img[:, ::-1, :]).all()
+    assert (tfmed.img == np.array(img)[:, ::-1, :]).all()
     check_attributes_on_component(tfmed)
 
 

--- a/tests/utils/test_imageio.py
+++ b/tests/utils/test_imageio.py
@@ -11,16 +11,13 @@ from icevision.all import *
 )
 def test_open_img(samples_source, fn, expected):
     # When returning np arrays
-    assert open_img(samples_source / fn).shape == expected
-    assert open_img(samples_source / fn, gray=True).shape == expected[:-1]
-    assert isinstance(open_img(samples_source / fn), np.ndarray)
+    assert np.array(open_img(samples_source / fn)).shape == expected
+    assert np.array(open_img(samples_source / fn, gray=True)).shape == expected[:-1]
 
     # When returning PIL Images; returns only (W,H) for size, not num. channels
-    assert open_img(samples_source / fn, as_array=False).shape == expected[:2]
-    assert (
-        open_img(samples_source / fn, gray=True, as_array=False).shape == expected[:-1]
-    )
-    assert isinstance(open_img(samples_source / fn, as_array=False), PIL.Image.Image)
+    assert open_img(samples_source / fn).shape == expected[:2]
+    assert open_img(samples_source / fn, gray=True).shape == expected[:-1]
+    assert isinstance(open_img(samples_source / fn), PIL.Image.Image)
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_imageio.py
+++ b/tests/utils/test_imageio.py
@@ -10,8 +10,17 @@ from icevision.all import *
     ],
 )
 def test_open_img(samples_source, fn, expected):
+    # When returning np arrays
     assert open_img(samples_source / fn).shape == expected
     assert open_img(samples_source / fn, gray=True).shape == expected[:-1]
+    assert isinstance(open_img(samples_source / fn), np.ndarray)
+
+    # When returning PIL Images; returns only (W,H) for size, not num. channels
+    assert open_img(samples_source / fn, as_array=False).shape == expected[:2]
+    assert (
+        open_img(samples_source / fn, gray=True, as_array=False).shape == expected[:-1]
+    )
+    assert isinstance(open_img(samples_source / fn, as_array=False), PIL.Image.Image)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is a minimal PR whose aim is just to add the ability to return a `PIL.Image.Image` inside the record components. Backward compatibility is maintained and a `np.ndarray` is returned by default.

This will open the door to `torchvision.transforms` pipelines or `PIL.Image` transforms without additional overhead as we've currently assumed the transforms pipeline to be done using `albumentations`. 