### PR TITLE
Use record in end2end_detect

### DIFF
--- a/.github/workflows/ci-all-testing.yml
+++ b/.github/workflows/ci-all-testing.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Install package
       run: |
         pip install torch=="1.8.1+cpu" torchvision=="0.9.1+cpu" -f https://download.pytorch.org/whl/torch_stable.html
-        pip install mmcv-full=="1.3.2+torch.1.8.0+cpu" -f https://download.openmmlab.com/mmcv/dist/index.html --use-deprecated=legacy-resolver
-        pip install mmdet
+        pip install mmcv-full=="1.3.5+torch.1.8.0+cpu" -f https://download.openmmlab.com/mmcv/dist/index.html --use-deprecated=legacy-resolver
+        pip install mmdet==2.13
         pip install -e ".[all,dev]"
         pip install yolov5-icevision --upgrade
 

--- a/.github/workflows/ci-all-testing.yml
+++ b/.github/workflows/ci-all-testing.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         pip install torch=="1.8.1+cpu" torchvision=="0.9.1+cpu" -f https://download.pytorch.org/whl/torch_stable.html
         pip install mmcv-full=="1.3.2+torch.1.8.0+cpu" -f https://download.openmmlab.com/mmcv/dist/index.html --use-deprecated=legacy-resolver
-        pip install mmdet==2.12.0
+        pip install mmdet==2.12.0 --upgrade
         pip install -e ".[all,dev]"
         pip install yolov5-icevision --upgrade
 

--- a/.github/workflows/ci-all-testing.yml
+++ b/.github/workflows/ci-all-testing.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         pip install torch=="1.8.1+cpu" torchvision=="0.9.1+cpu" -f https://download.pytorch.org/whl/torch_stable.html
         pip install mmcv-full=="1.3.2+torch.1.8.0+cpu" -f https://download.openmmlab.com/mmcv/dist/index.html --use-deprecated=legacy-resolver
-        pip install mmdet==2.12
+        pip install mmdet==2.12.0
         pip install -e ".[all,dev]"
         pip install yolov5-icevision --upgrade
 

--- a/.github/workflows/ci-all-testing.yml
+++ b/.github/workflows/ci-all-testing.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Install package
       run: |
         pip install torch=="1.8.1+cpu" torchvision=="0.9.1+cpu" -f https://download.pytorch.org/whl/torch_stable.html
-        pip install mmcv-full=="1.3.5+torch.1.8.0+cpu" -f https://download.openmmlab.com/mmcv/dist/index.html --use-deprecated=legacy-resolver
-        pip install mmdet==2.13
+        pip install mmcv-full=="1.3.2+torch.1.8.0+cpu" -f https://download.openmmlab.com/mmcv/dist/index.html --use-deprecated=legacy-resolver
+        pip install mmdet==2.12
         pip install -e ".[all,dev]"
         pip install yolov5-icevision --upgrade
 

--- a/.github/workflows/mk-docs-build.yml
+++ b/.github/workflows/mk-docs-build.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           pip install torch=="1.8.1+cpu" torchvision=="0.9.1+cpu" -f https://download.pytorch.org/whl/torch_stable.html
           pip install mmcv-full=="1.3.2+torch.1.8.0+cpu" -f https://download.openmmlab.com/mmcv/dist/index.html --use-deprecated=legacy-resolver
-          pip install mmdet
+          pip install mmdet==2.12.0 --upgrade
           pip install -e ".[all,dev]"
           pip install yolov5-icevision --upgrade
           # Below version is needed to work around a clash with ruamel-yaml. When v1.0 is released this can be removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.8.1]
+### Added 
+- `end2end_detect()`: Run Object Detection inference (only `bboxes`) on a single image, and return predicted boxes corresponding to original image size
+-**Breaking:** BaseLabelsRecordComponent `as_dict()` now returns both `labels` `and labels_ids`. `labels` are now strings instead of integers.
+ 
 ## [0.8.0]
 Supports pytorch 1.8
 ### Added

--- a/icevision/core/record_components.py
+++ b/icevision/core/record_components.py
@@ -254,8 +254,7 @@ class BaseLabelsRecordComponent(ClassMapRecordComponent):
 
     def _num_annotations(self) -> Dict[str, int]:
         return {
-            "labels": len(self.labels),
-            "label_ids": len(self.label_ids),
+            "labels": len(self.label_ids),
         }
 
     def _autofix(self) -> Dict[str, bool]:
@@ -271,7 +270,10 @@ class BaseLabelsRecordComponent(ClassMapRecordComponent):
         return [*super()._repr(), f"Labels: {self.label_ids}"]
 
     def as_dict(self) -> dict:
-        return {"labels": self.label_ids}
+        return {
+            "labels": self.labels,
+            "label_ids": self.label_ids,
+        }
 
     def _builder_template(self) -> List[str]:
         return [

--- a/icevision/core/record_components.py
+++ b/icevision/core/record_components.py
@@ -253,7 +253,10 @@ class BaseLabelsRecordComponent(ClassMapRecordComponent):
         return [self.class_map.get_by_name(name) for name in labels_names]
 
     def _num_annotations(self) -> Dict[str, int]:
-        return {"labels": len(self.label_ids)}
+        return {
+            "labels": len(self.labels),
+            "label_ids": len(self.label_ids),
+        }
 
     def _autofix(self) -> Dict[str, bool]:
         return {"labels": [True] * len(self.label_ids)}

--- a/icevision/models/inference.py
+++ b/icevision/models/inference.py
@@ -77,6 +77,7 @@ def process_bbox_predictions(
         bbox = BBox.from_xyxy(xmin, ymin, xmax, ymax)
         bboxes.append(bbox)
 
+    pred.pred.img = np.array(img)
     pred.pred.detection.set_bboxes(bboxes)
     return pred
 

--- a/icevision/models/inference.py
+++ b/icevision/models/inference.py
@@ -29,6 +29,7 @@ def _end2end_detect(
     font_size: Union[int, float] = 12,
     label_color: Union[np.array, list, tuple, str] = ("#C4C4C4"),  # Mild Gray
     return_as_pil_img=True,
+    return_img=True,
 ):
     """
     Run Object Detection inference (only `bboxes`) on a single image.
@@ -51,29 +52,31 @@ def _end2end_detect(
     infer_ds = Dataset.from_images([np.array(img)], transforms, class_map=class_map)
     pred = predict_fn(model, infer_ds, detection_threshold=detection_threshold)[0]
     pred = process_bbox_predictions(pred, img, transforms.tfms_list)
+    record = pred.pred
 
     # draw image, return it as PIL image by default otherwise as numpy array
-    pred_img = draw_record(
-        record=pred,
-        class_map=class_map,
-        display_label=display_label,
-        display_score=display_score,
-        display_bbox=display_bbox,
-        font_path=font_path,
-        font_size=font_size,
-        label_color=label_color,
-        return_as_pil_img=return_as_pil_img,
-    )
-
-    record = pred.pred
-    record.set_img(pred_img)
+    if return_img:
+        pred_img = draw_record(
+            record=pred,
+            class_map=class_map,
+            display_label=display_label,
+            display_score=display_score,
+            display_bbox=display_bbox,
+            font_path=font_path,
+            font_size=font_size,
+            label_color=label_color,
+            return_as_pil_img=return_as_pil_img,
+        )
+        record.set_img(pred_img)
+    else:
+        record.set_img(None)
 
     w, h = img.shape
     record.set_img_size(ImgSize(width=w, height=h))
 
     # return a dict that contains the image with its predicted boxes (i.e. with resized boxes that match the original image size)
-    # and all the info regarding the boxes, labels, and prediction scores
-    return pred_img, record.as_dict()
+    # labels, and prediction scores
+    return record.as_dict()
 
 
 def process_bbox_predictions(

--- a/icevision/models/inference.py
+++ b/icevision/models/inference.py
@@ -11,6 +11,7 @@ from icevision.tfms.albumentations import albumentations_adapter
 from icevision.utils.imageio import *
 from icevision.visualize.draw_data import *
 
+DEFAULT_FONT_PATH = get_default_font()
 
 def _end2end_detect(
     img: Union[PIL.Image.Image, Path, str],

--- a/icevision/models/inference.py
+++ b/icevision/models/inference.py
@@ -43,7 +43,8 @@ def _end2end_detect(
     pred = process_bbox_predictions(pred, img, transforms.tfms_list)
     
     # return the record that contains the updated prediction (i.e. with resized boxes that match the original image size)
-    return pred.pred
+    # also return a dict in case the user needs to return a json object
+    return pred.pred, pred.pred.as_dict()
 
 
 def process_bbox_predictions(

--- a/icevision/models/inference.py
+++ b/icevision/models/inference.py
@@ -64,14 +64,15 @@ def _end2end_detect(
         return_as_pil_img=return_as_pil_img,
     )
 
-    pred.pred['common']['img'] = pred_img
+    record = pred.pred
+    record['common']['img'] = pred_img
     
     w, h = img.shape
-    pred.pred.set_img_size(ImgSize(width=w, height=h))
+    record.set_img_size(ImgSize(width=w, height=h))
 
     # return a dict that contains the image with its predicted boxes (i.e. with resized boxes that match the original image size)
     # and all the info regarding the boxes, labels, and prediction scores
-    return pred.pred['common']['img'], pred.pred.as_dict()
+    return record['common']['img'], record.as_dict()
 
 
 def process_bbox_predictions(

--- a/icevision/models/inference.py
+++ b/icevision/models/inference.py
@@ -1,4 +1,4 @@
-__all__ = ["process_bbox_predictions", "_end2end_detect"]
+__all__ = ["process_bbox_predictions", "_end2end_detect", "draw_img_and_boxes"]
 
 from icevision.imports import *
 from icevision.core import *
@@ -139,12 +139,12 @@ def draw_img_and_boxes(
     bboxes: dict,
     class_map,
     display_score: bool = True,
-    label_color: Union[np.array, list, tuple, str] = (255, 255, 0), 
-    label_border_color: Union[np.array, list, tuple, str] = (255, 255, 0), 
-    ) -> PIL.Image.Image:
-    
+    label_color: Union[np.array, list, tuple, str] = (255, 255, 0),
+    label_border_color: Union[np.array, list, tuple, str] = (255, 255, 0),
+) -> PIL.Image.Image:
+
     if not isinstance(img, PIL.Image.Image):
-      img = np.array(img)
+        img = np.array(img)
 
     # convert dict to record
     record = ObjectDetectionRecord()
@@ -153,17 +153,18 @@ def draw_img_and_boxes(
     record.set_img_size(ImgSize(width=w, height=h))
     record.detection.set_class_map(class_map)
     for bbox in bboxes:
-        record.detection.add_bboxes([BBox.from_xyxy(*bbox['bbox'])])
-        if display_score== True:
-          score = bbox['score']
-          score = f"{score * 100: .2f}%"
-          label = bbox['class']
-          # label = f"{label}: {score}"
-          record.detection.add_labels([label])
+        record.detection.add_bboxes([BBox.from_xyxy(*bbox["bbox"])])
+        if display_score == True:
+            score = bbox["score"]
+            score = f"{score * 100: .2f}%"
+            label = bbox["class"]
+            # label = f"{label}: {score}"
+            record.detection.add_labels([label])
         else:
-          record.detection.add_labels([bbox['class']])
-        
+            record.detection.add_labels([bbox["class"]])
 
-    pred_img = draw_sample(record, label_color=label_color, label_border_color=label_border_color)
+    pred_img = draw_sample(
+        record, label_color=label_color, label_border_color=label_border_color
+    )
 
     return pred_img

--- a/icevision/models/inference.py
+++ b/icevision/models/inference.py
@@ -69,7 +69,7 @@ def _end2end_detect(
         )
         record.set_img(pred_img)
     else:
-        record.set_img(None)
+        record._unload()
 
     w, h = img.shape
     record.set_img_size(ImgSize(width=w, height=h))

--- a/icevision/models/inference.py
+++ b/icevision/models/inference.py
@@ -10,6 +10,7 @@ from icevision.tfms.albumentations import albumentations_adapter
 
 from icevision.utils.imageio import *
 from icevision.visualize.draw_data import *
+from icevision.visualize.utils import *
 
 DEFAULT_FONT_PATH = get_default_font()
 

--- a/icevision/models/inference.py
+++ b/icevision/models/inference.py
@@ -64,10 +64,14 @@ def _end2end_detect(
         return_as_pil_img=return_as_pil_img,
     )
 
-    pred.pred.img = pred_img
+    pred.pred['common']['img'] = pred_img
+    
+    w, h = img.shape
+    pred.pred.set_img_size(ImgSize(width=w, height=h))
+
     # return a dict that contains the image with its predicted boxes (i.e. with resized boxes that match the original image size)
     # and all the info regarding the boxes, labels, and prediction scores
-    return pred.pred.as_dict()
+    return pred.pred['common']['img'], pred.pred.as_dict()
 
 
 def process_bbox_predictions(

--- a/icevision/models/inference.py
+++ b/icevision/models/inference.py
@@ -154,17 +154,14 @@ def draw_img_and_boxes(
     record.detection.set_class_map(class_map)
     for bbox in bboxes:
         record.detection.add_bboxes([BBox.from_xyxy(*bbox["bbox"])])
-        if display_score == True:
-            score = bbox["score"]
-            score = f"{score * 100: .2f}%"
-            label = bbox["class"]
-            # label = f"{label}: {score}"
-            record.detection.add_labels([label])
-        else:
-            record.detection.add_labels([bbox["class"]])
+        record.detection.add_labels([bbox["class"]])
+        pred.detection.set_scores(bbox["score"])
 
     pred_img = draw_sample(
-        record, label_color=label_color, label_border_color=label_border_color
+        record,
+        display_score=display_score,
+        label_color=label_color,
+        label_border_color=label_border_color,
     )
 
     return pred_img

--- a/icevision/models/inference.py
+++ b/icevision/models/inference.py
@@ -14,6 +14,7 @@ from icevision.visualize.utils import *
 
 DEFAULT_FONT_PATH = get_default_font()
 
+
 def _end2end_detect(
     img: Union[PIL.Image.Image, Path, str],
     transforms: albumentations_adapter.Adapter,
@@ -53,8 +54,8 @@ def _end2end_detect(
 
     # draw image, return it as PIL image by default otherwise as numpy array
     pred_img = draw_record(
-        record=pred, 
-        class_map=class_map, 
+        record=pred,
+        class_map=class_map,
         display_label=display_label,
         display_score=display_score,
         display_bbox=display_bbox,
@@ -65,14 +66,14 @@ def _end2end_detect(
     )
 
     record = pred.pred
-    record['common']['img'] = pred_img
-    
+    record.set_img(pred_img)
+
     w, h = img.shape
     record.set_img_size(ImgSize(width=w, height=h))
 
     # return a dict that contains the image with its predicted boxes (i.e. with resized boxes that match the original image size)
     # and all the info regarding the boxes, labels, and prediction scores
-    return record['common']['img'], record.as_dict()
+    return pred_img, record.as_dict()
 
 
 def process_bbox_predictions(
@@ -102,7 +103,7 @@ def process_bbox_predictions(
         xmin, ymin, xmax, ymax = postprocess_bbox(
             img, bbox, transforms, pred.pred.height, pred.pred.width
         )
-        
+
         bbox = BBox.from_xyxy(xmin, ymin, xmax, ymax)
         bboxes.append(bbox)
 

--- a/icevision/models/inference.py
+++ b/icevision/models/inference.py
@@ -53,7 +53,7 @@ def _end2end_detect(
 
     Returns
     -------
-    A dictionnary with categories, scores, bounding box coordinates, image height and width, 
+    A dictionnary with categories, scores, bounding box coordinates, image height and width,
                    and optionally a PIL Image or a numpy array (image).
                    Bounding boxes are adjusted to the original image size and aspect ratio
     """

--- a/icevision/models/inference.py
+++ b/icevision/models/inference.py
@@ -75,21 +75,22 @@ def _end2end_detect(
     record.set_img_size(ImgSize(width=w, height=h))
 
     pred_dict = record.as_dict()
-    
+
     # expose img at the root instead of having under the `common` key
     if return_img:
-      pred_dict['img'] = pred_img
+        pred_dict["img"] = pred_img
     else:
-       pred_dict['img'] = None
+        pred_dict["img"] = None
 
-    pred_dict['width'] = w
-    pred_dict['height'] = h   
+    pred_dict["width"] = w
+    pred_dict["height"] = h
     # delete the `common` key that holds both the `img` and its shape
-    del pred_dict['common']
+    del pred_dict["common"]
 
     # return a dict that contains the image with its predicted boxes (i.e. with resized boxes that match the original image size)
     # labels, and prediction scores
     return pred_dict
+
 
 def process_bbox_predictions(
     pred: Prediction,

--- a/icevision/models/inference.py
+++ b/icevision/models/inference.py
@@ -74,10 +74,22 @@ def _end2end_detect(
     w, h = img.shape
     record.set_img_size(ImgSize(width=w, height=h))
 
+    pred_dict = record.as_dict()
+    
+    # expose img at the root instead of having under the `common` key
+    if return_img:
+      pred_dict['img'] = pred_img
+    else:
+       pred_dict['img'] = None
+
+    pred_dict['width'] = w
+    pred_dict['height'] = h   
+    # delete the `common` key that holds both the `img` and its shape
+    del pred_dict['common']
+
     # return a dict that contains the image with its predicted boxes (i.e. with resized boxes that match the original image size)
     # labels, and prediction scores
-    return record.as_dict()
-
+    return pred_dict
 
 def process_bbox_predictions(
     pred: Prediction,

--- a/icevision/models/inference.py
+++ b/icevision/models/inference.py
@@ -36,15 +36,26 @@ def _end2end_detect(
 
     Parameters
     ----------
-    img: image to run inference on. Can be a string, Path or PIL.Image
+    img: image to run inference on. It can be a string, Path or PIL.Image
     transforms: icevision albumentations transforms
     model: model to run inference with
     class_map: ClassMap with the available categories
-    detection_threshold: confidence threshold below which boxes are discarded
+    detection_threshold: confidence threshold below which bounding boxes are discarded
+    display_label: display or not a bounding box label(i.e class)
+    display_bbox: display or not a bounding box
+    display_score: display or not a bounding box score
+    font_path: path to the font file used
+    font_size: font size
+    label_color: a <collection> of RGB values or a hex code string that defines
+                   the color of all the plotted labels
+    return_as_pil_img: if True a PIL image is returned otherwise a numpy array is returned
+    return_img: whether we should also return an image in addition to the bounding boxes, labels, and scores
 
     Returns
     -------
-    List of dicts with category, score and bbox coordinates adjusted to original image size and aspect ratio
+    A dictionnary with categories, scores, bounding box coordinates, image height and width, 
+                   and optionally a PIL Image or a numpy array (image).
+                   Bounding boxes are adjusted to the original image size and aspect ratio
     """
     if isinstance(img, (str, Path)):
         img = PIL.Image.open(Path(img))

--- a/icevision/visualize/draw_data.py
+++ b/icevision/visualize/draw_data.py
@@ -9,6 +9,7 @@ __all__ = [
     "draw_bbox",
     "draw_mask",
     "draw_keypoints",
+    "draw_label"
 ]
 
 from icevision.imports import *

--- a/icevision/visualize/draw_data.py
+++ b/icevision/visualize/draw_data.py
@@ -9,7 +9,7 @@ __all__ = [
     "draw_bbox",
     "draw_mask",
     "draw_keypoints",
-    "draw_label"
+    "draw_label",
 ]
 
 from icevision.imports import *

--- a/tests/models/efficient_det/test_prediction.py
+++ b/tests/models/efficient_det/test_prediction.py
@@ -7,10 +7,10 @@ from icevision.models.inference import postprocess_bbox
 def test_e2e_detect(samples_source, fridge_efficientdet_model, fridge_class_map):
     img_path = samples_source / "fridge/odFridgeObjects/images/10.jpg"
     tfms_ = tfms.A.Adapter([*tfms.A.resize_and_pad(384), tfms.A.Normalize()])
-    bboxes = efficientdet.end2end_detect(
+    pred_dict = efficientdet.end2end_detect(
         img_path, tfms_, fridge_efficientdet_model, fridge_class_map
     )
-    assert len(bboxes) == 2
+    assert len(pred_dict['detection']['bboxes']) == 2
 
 
 def test_inference_postprocess_bbox(samples_source, fridge_efficientdet_model):

--- a/tests/models/efficient_det/test_prediction.py
+++ b/tests/models/efficient_det/test_prediction.py
@@ -10,7 +10,7 @@ def test_e2e_detect(samples_source, fridge_efficientdet_model, fridge_class_map)
     pred_dict = efficientdet.end2end_detect(
         img_path, tfms_, fridge_efficientdet_model, fridge_class_map
     )
-    assert len(pred_dict['detection']['bboxes']) == 2
+    assert len(pred_dict["detection"]["bboxes"]) == 2
 
 
 def test_inference_postprocess_bbox(samples_source, fridge_efficientdet_model):

--- a/tests/models/torchvision_models/faster_rcnn/test_model.py
+++ b/tests/models/torchvision_models/faster_rcnn/test_model.py
@@ -19,10 +19,10 @@ def test_e2e_detect(samples_source, fridge_class_map, model_name, param_groups_l
     backbone = backbone_fn(pretrained=False)
     model = faster_rcnn.model(num_classes=4, backbone=backbone)
 
-    bboxes = faster_rcnn.end2end_detect(
+    pred_dict = faster_rcnn.end2end_detect(
         img_path, tfms_, model, fridge_class_map, detection_threshold=1
     )
-    assert len(bboxes) == 0
+    assert len(pred_dict['detection']['bboxes']) == 0
 
 
 def test_faster_rcnn_default_param_groups():

--- a/tests/models/torchvision_models/faster_rcnn/test_model.py
+++ b/tests/models/torchvision_models/faster_rcnn/test_model.py
@@ -22,7 +22,7 @@ def test_e2e_detect(samples_source, fridge_class_map, model_name, param_groups_l
     pred_dict = faster_rcnn.end2end_detect(
         img_path, tfms_, model, fridge_class_map, detection_threshold=1
     )
-    assert len(pred_dict['detection']['bboxes']) == 0
+    assert len(pred_dict["detection"]["bboxes"]) == 0
 
 
 def test_faster_rcnn_default_param_groups():

--- a/tests/models/ultralytics/yolov5/test_prediction.py
+++ b/tests/models/ultralytics/yolov5/test_prediction.py
@@ -17,8 +17,7 @@ def test_e2e_detect(samples_source, fridge_class_map, backbone):
     pred_dict = models.ultralytics.yolov5.end2end_detect(
         img_path, tfms_, model, fridge_class_map
     )
-    assert len(pred_dict['detection']['bboxes']) == 0
-
+    assert len(pred_dict["detection"]["bboxes"]) == 0
 
 
 def _test_preds(preds):

--- a/tests/models/ultralytics/yolov5/test_prediction.py
+++ b/tests/models/ultralytics/yolov5/test_prediction.py
@@ -14,10 +14,11 @@ def test_e2e_detect(samples_source, fridge_class_map, backbone):
     model = models.ultralytics.yolov5.model(
         num_classes=5, img_size=384, backbone=backbone(pretrained=True)
     )
-    bboxes = models.ultralytics.yolov5.end2end_detect(
+    pred_dict = models.ultralytics.yolov5.end2end_detect(
         img_path, tfms_, model, fridge_class_map
     )
-    assert len(bboxes) == 0
+    assert len(pred_dict['detection']['bboxes']) == 0
+
 
 
 def _test_preds(preds):


### PR DESCRIPTION
Change `end2end_detect()` to return a record in order to use `draw_record()` instead of creating a new brand draw method.