### PR TITLE
Fix download_mmdet_configs() method

### DIFF
--- a/icevision/models/mmdet/download_configs.py
+++ b/icevision/models/mmdet/download_configs.py
@@ -9,12 +9,26 @@ BASE_URL = "https://codeload.github.com/airctic/mmdetection_configs/zip/refs/tag
 
 def download_mmdet_configs() -> Path:
     save_dir = get_root_dir() / f"mmdetection_configs"
-    save_dir.mkdir(parents=True, exist_ok=True)
 
+    mmdet_config_path = save_dir / f"mmdetection_configs-{VERSION[1:]}/configs"
     download_path = save_dir / f"{VERSION}.zip"
-    if not download_path.exists():
-        logger.info("Downloading mmdet configs")
 
-        download_and_extract(f"{BASE_URL}/{VERSION}", download_path)
+    if mmdet_config_path.exists():
+        logger.info(
+            f"The mmdet config folder already exists. No need to downloaded it. Path : {mmdet_config_path}"
+        )
+    elif download_path.exists():
+        # The zip file was downloaded by not extracted yet
+        # Extract zip file
+        logger.info(f"Extracting the {VERSION}.zip file.")
+        save_dir = Path(download_path).parent
+        shutil.unpack_archive(filename=str(download_path), extract_dir=str(save_dir))
+    else:
+        save_dir.mkdir(parents=True, exist_ok=True)
 
-    return save_dir / f"mmdetection_configs-{VERSION[1:]}/configs"
+        download_path = save_dir / f"{VERSION}.zip"
+        if not download_path.exists():
+            logger.info("Downloading mmdet configs")
+            download_and_extract(f"{BASE_URL}/{VERSION}", download_path)
+
+    return mmdet_config_path


### PR DESCRIPTION
No need to download the zip file if it exists. This will solve the issue encountered in the Kaggle offline installation.

closes #877 