### PR TITLE
Fixed PIL size bug in ImageRecordComponent (#889)

### DIFF
--- a/icevision/core/record_components.py
+++ b/icevision/core/record_components.py
@@ -115,7 +115,7 @@ class ImageRecordComponent(RecordComponent):
         assert isinstance(img, (PIL.Image.Image, np.ndarray))
         self.img = img
         if isinstance(img, PIL.Image.Image):
-            height, width = img.shape
+            width, height = img.size
         elif isinstance(img, np.ndarray):
             # else:
             height, width, _ = self.img.shape
@@ -136,7 +136,7 @@ class ImageRecordComponent(RecordComponent):
                     )
                 return [f"Img: {width}x{height}x{channels} <np.ndarray> Image"]
             elif isinstance(self.img, PIL.Image.Image):
-                height, width = self.img.shape
+                width, height = self.img.size
                 return [f"Img: {width}x{height} <PIL.Image; mode='{self.img.mode}'>"]
         else:
             return [f"Img: {self.img}"]


### PR DESCRIPTION
Fixed how image size is returned for PIL image objects in ImageRecordComponent

Closes #889 