### PR TITLE
Fix mmdet weights path issue

### DIFF
--- a/icevision/models/mmdet/utils.py
+++ b/icevision/models/mmdet/utils.py
@@ -68,6 +68,7 @@ def create_model_config(
     weights_url = backbone.weights_url
 
     # download weights
+    weights_path = None
     if pretrained and weights_url:
         save_dir = Path(checkpoints_path) / model_name
         save_dir.mkdir(exist_ok=True, parents=True)

--- a/tests/models/mmdet/test_model.py
+++ b/tests/models/mmdet/test_model.py
@@ -3,16 +3,14 @@ from icevision.all import *
 
 
 @pytest.mark.parametrize(
-    "ds, model_type",
-    [
-        (
-            "fridge_ds",
-            models.mmdet.retinanet,
-        ),
-    ],
+    "ds, model_type, pretrained",
+    (
+        ("fridge_ds", models.mmdet.retinanet, True),
+        ("fridge_ds", models.mmdet.retinanet, False),
+    ),
 )
 class TestBboxModels:
-    def dls_model(self, ds, model_type, samples_source, request):
+    def dls_model(self, ds, model_type, pretrained, samples_source, request):
         train_ds, valid_ds = request.getfixturevalue(ds)
         train_dl = model_type.train_dl(train_ds, batch_size=2)
         valid_dl = model_type.valid_dl(valid_ds, batch_size=2)
@@ -20,13 +18,17 @@ class TestBboxModels:
         backbone = model_type.backbones.resnet50_fpn_1x()
         backbone.config_path = samples_source / backbone.config_path
 
-        model = model_type.model(backbone=backbone, num_classes=5)
+        model = model_type.model(
+            backbone=backbone(pretrained=pretrained), num_classes=5
+        )
 
         return train_dl, valid_dl, model
 
-    def test_mmdet_bbox_models_fastai(self, ds, model_type, samples_source, request):
+    def test_mmdet_bbox_models_fastai(
+        self, ds, model_type, pretrained, samples_source, request
+    ):
         train_dl, valid_dl, model = self.dls_model(
-            ds, model_type, samples_source, request
+            ds, model_type, pretrained, samples_source, request
         )
 
         learn = model_type.fastai.learner(
@@ -34,9 +36,11 @@ class TestBboxModels:
         )
         learn.fine_tune(1, 3e-4)
 
-    def test_mmdet_bbox_models_light(self, ds, model_type, samples_source, request):
+    def test_mmdet_bbox_models_light(
+        self, ds, model_type, pretrained, samples_source, request
+    ):
         train_dl, valid_dl, model = self.dls_model(
-            ds, model_type, samples_source, request
+            ds, model_type, pretrained, samples_source, request
         )
 
         class LitModel(model_type.lightning.ModelAdapter):


### PR DESCRIPTION
I Fixed mmdet weights path issue: When we pass `pretrained =False` to a backbone, the` weights_path` is not initialized and there an error is raised.