### PR TITLE
Make MMDetection config object accessible to users

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
     - How to use negative samples: negative_samples.md
     - Fixed Splitter: voc_predefined_splits.md
     - Progressive resizing: progressive_resizing.md
+    - MMDetection Custom Config: mmdet_custom_config.md
   - Transforms:
     - Albumentations: albumentations.md 
   - Models: models.md

--- a/icevision/models/mmdet/common/bbox/single_stage/model.py
+++ b/icevision/models/mmdet/common/bbox/single_stage/model.py
@@ -24,5 +24,5 @@ def model(
         pretrained=backbone.pretrained,
         checkpoints_path=checkpoints_path,
         force_download=force_download,
-        cfg_options=cfg_options
+        cfg_options=cfg_options,
     )

--- a/icevision/models/mmdet/common/bbox/single_stage/model.py
+++ b/icevision/models/mmdet/common/bbox/single_stage/model.py
@@ -14,6 +14,7 @@ def model(
     num_classes: int,
     checkpoints_path: Optional[Union[str, Path]] = "checkpoints",
     force_download=False,
+    cfg_options=None,
 ) -> nn.Module:
 
     return build_model(
@@ -23,4 +24,5 @@ def model(
         pretrained=backbone.pretrained,
         checkpoints_path=checkpoints_path,
         force_download=force_download,
+        cfg_options=cfg_options
     )

--- a/icevision/models/mmdet/common/utils.py
+++ b/icevision/models/mmdet/common/utils.py
@@ -3,7 +3,6 @@ __all__ = [
     "convert_background_from_last_to_zero",
     "mmdet_tensor_to_image",
     "build_model",
-    "rebuild_model",
 ]
 
 from icevision.imports import *
@@ -78,19 +77,4 @@ def build_model(
 
     return _model
 
-
-def rebuild_model(model): 
-    cfg = model.cfg
-    weights_path = model.weights_path
-
-    _model = build_detector(cfg.model, cfg.get("train_cfg"), cfg.get("test_cfg"))
-
-    if (weights_path is not None):
-        load_checkpoint(_model, str(weights_path))
-
-    _model.param_groups = MethodType(param_groups, _model)
-    _model.cfg = cfg  # save the config in the model for convenience
-    _model.weights_path = weights_path # save the model.weights_path in case we want to rebuild the model after updating its attributes
-
-    return _model
 

--- a/icevision/models/mmdet/common/utils.py
+++ b/icevision/models/mmdet/common/utils.py
@@ -73,8 +73,6 @@ def build_model(
 
     _model.param_groups = MethodType(param_groups, _model)
     _model.cfg = cfg  # save the config in the model for convenience
-    _model.weights_path = weights_path # save the model.weights_path in case we want to rebuild the model after updating its attributes
+    _model.weights_path = weights_path  # save the model.weights_path in case we want to rebuild the model after updating its attributes
 
     return _model
-
-

--- a/icevision/models/mmdet/utils.py
+++ b/icevision/models/mmdet/utils.py
@@ -83,7 +83,6 @@ def create_model_config(
     cfg = Config.fromfile(config_path)
 
     if cfg_options is not None:
-        print(f"Merging cfg_options: {cfg_options}")
         cfg.merge_from_dict(cfg_options)     
 
     return cfg, weights_path

--- a/icevision/models/mmdet/utils.py
+++ b/icevision/models/mmdet/utils.py
@@ -61,6 +61,7 @@ def create_model_config(
     pretrained: bool = True,
     checkpoints_path: Optional[Union[str, Path]] = "checkpoints",
     force_download=False,
+    cfg_options=None,
 ):
 
     model_name = backbone.model_name
@@ -80,5 +81,9 @@ def create_model_config(
             download_url(url=weights_url, save_path=str(weights_path))
 
     cfg = Config.fromfile(config_path)
+
+    if cfg_options is not None:
+        print(f"Merging cfg_options: {cfg_options}")
+        cfg.merge_from_dict(cfg_options)     
 
     return cfg, weights_path

--- a/icevision/models/mmdet/utils.py
+++ b/icevision/models/mmdet/utils.py
@@ -83,6 +83,6 @@ def create_model_config(
     cfg = Config.fromfile(config_path)
 
     if cfg_options is not None:
-        cfg.merge_from_dict(cfg_options)     
+        cfg.merge_from_dict(cfg_options)
 
     return cfg, weights_path


### PR DESCRIPTION
I'm make the MMDetection config object accessible to users. The goal is to be able to update model attributes: e.g. changing weighted loss parameters, changing anchor boxes ratios, etc.

```python
model_type = models.mmdet.retinanet
backbone = model_type.backbones.resnet50_fpn_1x
'cfg_options' = { 
  'model.bbox_head.loss_bbox.loss_weight': 2,
  'model.bbox_head.loss_cls.loss_weight': 0.8 }

# Passing cfg_options to the `model()` method to update loss weights
model = model_type.model(backbone=backbone(pretrained=True), num_classes=len(parser.class_map), cfg_options=cfg_options)
```

closes #903 