### PR TITLE
Update installation to torch  1.9 + dependencies

### DIFF
--- a/icevision/models/mmdet/download_configs.py
+++ b/icevision/models/mmdet/download_configs.py
@@ -3,7 +3,7 @@ __all__ = ["download_mmdet_configs"]
 from icevision.imports import *
 from icevision.utils import *
 
-VERSION = "v2.10.0"
+VERSION = "v2.16.0"
 BASE_URL = "https://codeload.github.com/airctic/mmdetection_configs/zip/refs/tags"
 
 

--- a/install_colab.sh
+++ b/install_colab.sh
@@ -1,34 +1,18 @@
-echo "Installing icevision + dependencices for CUDA 10"
-echo "Uninstalling some dependencies to prevent errors"
-pip uninstall torchvision -y
-pip uninstall fastai -y
+!pip install openmim -q
+!echo "- Installing mmcv"
+!mim install mmcv-full
+!echo "- Installing mmdet"
+!mim install mmdet
 
- echo "Installing some dependencies to prevent errors"
-pip install PyYAML>=5.1 -U -q
-pip install datascience -U -q
-pip install tensorflow==2.4.0 -U -q
-pip install google-colab -U -q
 
-echo "- Installing torch and its dependencies"
-echo "- Installing torch and its dependencies"
-pip install torchtext==0.9.0 -U -q
-pip install torch==1.8.0+cu101 torchvision==0.9.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html -U -q
+!echo "- Installing icevision from master"
+!pip install git+git://github.com/airctic/icevision.git -U -q
+!echo "- Installing icedata from master"      
+!pip install git+git://github.com/airctic/icedata.git -U -q
+!echo "- Installing yolov5-icevision" 
+!pip install yolov5-icevision -U -q 
 
-echo "- Installing fastai"
-pip install fastai==2.3.1 -U -q
-
-echo "- Installing icevision from master"
-pip install git+git://github.com/airctic/icevision.git#egg=icevision[all] -U -q
-echo "- Installing icedata from master"      
-pip install git+git://github.com/airctic/icedata.git -U -q
-echo "- Installing yolov5-icevision" 
-pip install yolov5-icevision -U -q 
-echo "- Installing mmcv"
-pip install mmcv-full==1.3.7 -f https://download.openmmlab.com/mmcv/dist/cu101/torch1.8.0/index.html -U -q
-echo "- Installing mmdet"
-pip install mmdet==2.13.0 -U -q
-echo "icevision installation finished"  
 
 # restart notebook
-echo "Restarting runtime!"
-kill -9 -1
+!echo "Restarting runtime!"
+!kill -9 -1

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,8 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires = 
-    torch >=1.7.0,<1.9
-    torchvision >=0.8.0,<0.10
+    torch >=1.7.0,<1.10
+    torchvision >=0.8.0,<0.11
     fastcore >=1.3.0,<1.4
     tqdm >=4.49.0,<5
     opencv-python >=4.1.1,<5
@@ -40,9 +40,9 @@ install_requires =
 
 [options.extras_require]
 all =
-    fastai >=2.1,<2.4
+    fastai >=2.5.2,<2.6
     ipykernel >=4.10.1,<6
-    pytorch-lightning >=1.2.10
+    pytorch-lightning >=1.4.5
     effdet >=0.2.1,<0.3
     omegaconf >=2,<3
     dataclasses ==0.6


### PR DESCRIPTION
The new installation requirements will avoid reinstalling torch, torchvision and all the other dependencies. Right now, icevision installation lasts more than 5 minutes on Colab because of the re-installation process.