### PR TITLE
casting both caption parts as str

### DIFF
--- a/icevision/visualize/draw_data.py
+++ b/icevision/visualize/draw_data.py
@@ -238,7 +238,7 @@ def draw_label(
         caption = str(label)
     if prettify:
         # We could introduce a callback here for more complex label renaming
-        caption = prefix + caption
+        caption = str(prefix) + str(caption)
         caption = prettify_func(caption)
 
     # Append label confidence to caption if applicable


### PR DESCRIPTION
Kept getting error at this line I changed:
```
TypeError: can only concatenate str (not "numpy.int64") to str
```
This fixes it, and should be otherwise harmless.