### PR TITLE
Install docs fix: MMCV >= 1.3.8, < 1.4, but not 1.3.3

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -79,7 +79,7 @@ We need to provide the appropriate version of the `mmcv-full` package as well as
 #### CUDA-Version Installation Example
 <div class="termy">
 ```console
-$ pip install mmcv-full=="1.3.3" -f https://download.openmmlab.com/mmcv/dist/CUDA_VERSION/TORCH_VERSION/index.html --upgrade
+$ pip install mmcv-full=="1.3.8" -f https://download.openmmlab.com/mmcv/dist/CUDA_VERSION/TORCH_VERSION/index.html --upgrade
 $ pip install mmdet
 ```
 </div>
@@ -87,7 +87,7 @@ $ pip install mmdet
 #### CPU-Version Installation
 <div class="termy">
 ```console
-$ pip install mmcv-full=="1.3.3+torch.1.8.0+cpu" -f https://download.openmmlab.com/mmcv/dist/index.html --upgrade
+$ pip install mmcv-full=="1.3.8+torch.1.8.0+cpu" -f https://download.openmmlab.com/mmcv/dist/index.html --upgrade
 $ pip install mmdet
 ```
 </div>

--- a/icevision/visualize/draw_data.py
+++ b/icevision/visualize/draw_data.py
@@ -238,7 +238,7 @@ def draw_label(
         caption = str(label)
     if prettify:
         # We could introduce a callback here for more complex label renaming
-        caption = prefix + caption
+        caption = str(prefix) + str(caption)
         caption = prettify_func(caption)
 
     # Append label confidence to caption if applicable


### PR DESCRIPTION
Fixes `MMCV==1.3.3 is used but incompatible. Please install mmcv>=1.3.8, <=1.4.0.`

BTW, here's some code I cooked up that may be of interest to other users.  Didn't put in in PR itself but would be happy to do so:

```Python
import torch, re 
tv, cv = torch.__version__, torch.version.cuda
tv = re.sub('\+cu.*','',tv)
TORCH_VERSION = 'torch'+tv[0:-1]+'0'
CUDA_VERSION = 'cu'+cv.replace('.','')

print(f"TORCH_VERSION={TORCH_VERSION}; CUDA_VERSION={CUDA_VERSION}")

!pip install -qq mmcv-full=="1.3.8" -f https://download.openmmlab.com/mmcv/dist/{CUDA_VERSION}/{TORCH_VERSION}/index.html --upgrade
!pip install mmdet -qq
```