### PR TITLE
Fix show pred

### DIFF
--- a/icevision/visualize/show_data.py
+++ b/icevision/visualize/show_data.py
@@ -75,6 +75,7 @@ def show_pred(
     ax: plt.Axes = None,
     figsize=None,
     annotation=None,
+    font_size=13,
     **draw_sample_kwargs,
 ) -> None:
     actual = draw_sample(
@@ -83,6 +84,7 @@ def show_pred(
         display_bbox=display_bbox,
         display_mask=display_mask,
         denormalize_fn=denormalize_fn,
+        font_size=font_size,
         **draw_sample_kwargs,
     )
 
@@ -92,6 +94,7 @@ def show_pred(
         display_label=display_label,
         display_bbox=display_bbox,
         display_mask=display_mask,
+        font_size=font_size,
         **draw_sample_kwargs,
     )
 

--- a/icevision/visualize/show_data.py
+++ b/icevision/visualize/show_data.py
@@ -83,6 +83,7 @@ def show_pred(
         display_bbox=display_bbox,
         display_mask=display_mask,
         denormalize_fn=denormalize_fn,
+        **draw_sample_kwargs,
     )
 
     prediction = draw_pred(


### PR DESCRIPTION
Since draw_sample_kwargs dict arg passing is missing, we cannot specify font size and other parameters for ground truth plotting. In `show_pred` some of the parameters have defined default values for `draw_pred` but not `draw_sample` which results in different plotting parameters set for records/preds displayed next to each other.
Before:
![image](https://user-images.githubusercontent.com/52150545/134337979-3d00f1a5-9de4-4cf8-9263-a5134e211659.png)

This PR unifies these values adding enforced default font size for both plots.
After:
![image](https://user-images.githubusercontent.com/52150545/134338215-8de4af85-69da-425e-9fdd-901bb6f7c9fd.png)
