### PR TITLE
Add support for yolox from mmdetection.

### DIFF
--- a/icevision/models/mmdet/models/__init__.py
+++ b/icevision/models/mmdet/models/__init__.py
@@ -1,5 +1,6 @@
 # object detection
 from icevision.models.mmdet.models import faster_rcnn
+from icevision.models.mmdet.models import yolox
 from icevision.models.mmdet.models import retinanet
 from icevision.models.mmdet.models import fcos
 from icevision.models.mmdet.models import vfnet

--- a/icevision/models/mmdet/models/yolox/__init__.py
+++ b/icevision/models/mmdet/models/yolox/__init__.py
@@ -1,0 +1,22 @@
+from icevision.models.mmdet.models.yolox import backbones
+from icevision.models.mmdet.common.bbox.single_stage import *
+from icevision.models.interpretation import Interpretation, _move_to_device
+from icevision.models.mmdet.common.interpretation_utils import (
+    sum_losses_mmdet,
+    loop_mmdet,
+)
+
+_LOSSES_DICT = {
+    "loss_cls": [],
+    "loss_bbox": [],
+    "loss_total": [],
+}
+
+interp = Interpretation(
+    losses_dict=_LOSSES_DICT,
+    valid_dl=valid_dl,
+    infer_dl=infer_dl,
+    predict_from_dl=predict_from_dl,
+)
+
+interp._loop = loop_mmdet

--- a/icevision/models/mmdet/models/yolox/backbones/__init__.py
+++ b/icevision/models/mmdet/models/yolox/backbones/__init__.py
@@ -1,0 +1,1 @@
+from icevision.models.mmdet.models.yolox.backbones.resnet_fpn import *

--- a/icevision/models/mmdet/models/yolox/backbones/resnet_fpn.py
+++ b/icevision/models/mmdet/models/yolox/backbones/resnet_fpn.py
@@ -9,7 +9,7 @@ from icevision.models.mmdet.utils import *
 class MMDetYOLOXBackboneConfig(MMDetBackboneConfig):
     def __init__(self, **kwargs):
         super().__init__(model_name="yolox", **kwargs)
-        
+
 
 base_config_path = mmdet_configs_path / "yolox"
 base_weights_url = (
@@ -18,5 +18,5 @@ base_weights_url = (
 
 yolox_tiny_8x8 = MMDetYOLOXBackboneConfig(
     config_path=base_config_path / "yolox_tiny_8x8_300e_coco.py",
-    weights_url=f"{base_weights_url}/yolox_tiny_8x8_300e_coco/yolox_tiny_8x8_300e_coco_20210806_234250-4ff3b67e.pth",
+    weights_url=f"{base_weights_url}yolox_tiny_8x8_300e_coco/yolox_tiny_8x8_300e_coco_20210806_234250-4ff3b67e.pth",
 )

--- a/icevision/models/mmdet/models/yolox/backbones/resnet_fpn.py
+++ b/icevision/models/mmdet/models/yolox/backbones/resnet_fpn.py
@@ -1,0 +1,22 @@
+__all__ = [
+    "yolox_tiny_8x8",
+]
+
+from icevision.imports import *
+from icevision.models.mmdet.utils import *
+
+
+class MMDetYOLOXBackboneConfig(MMDetBackboneConfig):
+    def __init__(self, **kwargs):
+        super().__init__(model_name="yolox", **kwargs)
+        
+
+base_config_path = mmdet_configs_path / "yolox"
+base_weights_url = (
+    "https://download.openmmlab.com/mmdetection/v2.0/yolox/"
+)
+
+yolox_tiny_8x8 = MMDetYOLOXBackboneConfig(
+    config_path=base_config_path / "yolox_tiny_8x8_300e_coco.py",
+    weights_url=f"{base_weights_url}/yolox_tiny_8x8_300e_coco/yolox_tiny_8x8_300e_coco_20210806_234250-4ff3b67e.pth",
+)

--- a/icevision/models/mmdet/utils.py
+++ b/icevision/models/mmdet/utils.py
@@ -41,6 +41,7 @@ def param_groups(model):
     elif isinstance(body, CSPDarknet):
         layers += [body.stem.conv.conv, body.stem.conv.bn]
         layers += [body.stage1, body.stage2, body.stage3, body.stage4]
+        layers += [model.neck]
     else:
         layers += [nn.Sequential(body.conv1, body.bn1)]
         layers += [getattr(body, l) for l in body.res_layers]

--- a/icevision/models/mmdet/utils.py
+++ b/icevision/models/mmdet/utils.py
@@ -13,6 +13,7 @@ from icevision.models.mmdet.download_configs import download_mmdet_configs
 from mmdet.models.detectors import *
 from mmcv import Config
 from mmdet.models.backbones.ssd_vgg import SSDVGG
+from mmdet.models.backbones.csp_darknet import CSPDarknet
 
 
 mmdet_configs_path = download_mmdet_configs()
@@ -37,6 +38,9 @@ def param_groups(model):
     if isinstance(body, SSDVGG):
         layers += [body.features]
         layers += [body.extra, body.l2_norm]
+    elif isinstance(body, CSPDarknet):
+        layers += [body.stem.conv.conv, body.stem.conv.bn]
+        layers += [body.stage1, body.stage2, body.stage3, body.stage4]
     else:
         layers += [nn.Sequential(body.conv1, body.bn1)]
         layers += [getattr(body, l) for l in body.res_layers]


### PR DESCRIPTION
1) For now, for testing you have to manually copy the yolox folder found in the mmdet 2.16.0 (https://github.com/open-mmlab/mmdetection/tree/master/configs) and paste in the icevision folder here: `~/.icevision/mmdetection_configs/mmdetection_configs-2.10.0/configs/`, and test the integration.
2) Also updating mmdet from notebook is necessary for now:
```
!pip install openmim -q
!echo "- Installing mmcv"
!mim install mmcv-full
!echo "- Installing mmdet"
!mim install mmdet

!echo "Restarting runtime!"
!kill -9 -1 
```