### PR TITLE
Empty mask fix

### DIFF
--- a/icevision/core/mask.py
+++ b/icevision/core/mask.py
@@ -82,9 +82,17 @@ class MaskArray(Mask):
         return self
 
     def to_erles(self, h, w) -> EncodedRLEs:
-        return EncodedRLEs(
-            mask_utils.encode(np.asfortranarray(self.data.transpose(1, 2, 0)))
-        )
+        # HACK: force empty annotations to have valid shape
+        if len(self.data.shape) == 1:
+            return EncodedRLEs(
+                mask_utils.encode(
+                    np.asfortranarray(self.data[:, None, None].transpose(1, 2, 0))
+                )
+            )
+        else:
+            return EncodedRLEs(
+                mask_utils.encode(np.asfortranarray(self.data.transpose(1, 2, 0)))
+            )
 
     def to_coco_rle(self, h, w) -> List[dict]:
         """From https://stackoverflow.com/a/49547872/6772672"""
@@ -111,7 +119,10 @@ class MaskArray(Mask):
             return masks.to_mask(h, w)
         else:
             masks_arrays = [o.to_mask(h=h, w=w).data for o in masks]
-            return cls(np.concatenate(masks_arrays))
+            if len(masks_arrays) == 0:
+                return cls(np.array([]))
+            else:
+                return cls(np.concatenate(masks_arrays))
 
 
 class MaskFile(Mask):

--- a/icevision/tfms/albumentations/albumentations_adapter.py
+++ b/icevision/tfms/albumentations/albumentations_adapter.py
@@ -301,9 +301,7 @@ class Adapter(Transform, Composite):
     #     return record
 
     def _filter_attribute(self, v: list):
-        if (
-            self._keep_mask is None
-        ):  # or len(self._keep_mask) == 0: # check whether self._keep_mask is an empty list
+        if self._keep_mask is None or len(self._keep_mask) == 0:
             return v
         assert len(v) == len(self._keep_mask)
         return [o for o, keep in zip(v, self._keep_mask) if keep]


### PR DESCRIPTION
Related to #913, fixes to the following:

* Force empty mask annotations to have valid shape with quick hack.
  * This was breaking `COCOMetric(metric_type=COCOMetricType.mask)`
* Avoid trying to concatenate empty masks
  * This was breaking a lot of things
* Just to be sure add check for empty `self._keep_mask` list in `albumentations_adapter/_filter_attribute`
  * This might not be needed anymore. Seems that original problem was related to faulty masks but at least I found some other bugs to squish