### PR TITLE
(Feature) Added way to output metrics for pytorchlightning during training

### DIFF
--- a/icevision/engines/lightning/lightning_model_adapter.py
+++ b/icevision/engines/lightning/lightning_model_adapter.py
@@ -19,7 +19,7 @@ class LightningModelAdapter(pl.LightningModule, ABC):
         super().__init__()
         self.metrics = metrics or []
         self.metrics_keys_to_log_to_prog_bar = metrics_keys_to_log_to_prog_bar or [
-            ("AP (IoU=0.50:0.95) area=all", "mAP")
+            ("AP (IoU=0.50:0.95) area=all", "COCOMetric")
         ]
 
     def accumulate_metrics(self, preds):

--- a/icevision/engines/lightning/lightning_model_adapter.py
+++ b/icevision/engines/lightning/lightning_model_adapter.py
@@ -6,9 +6,15 @@ from icevision.metrics import *
 
 
 class LightningModelAdapter(pl.LightningModule, ABC):
-    def __init__(self, metrics: List[Metric] = None):
+    def __init__(self, metrics: List[Metric] = None, metrics_keys_to_log_to_prog_bar: List[tuple] = None):
+        """
+        To show a metric in the progressbar a list of tupels can be provided for metrics_keys_to_log_to_prog_bar, the first
+        entry has to be the name of the metric to log and the second entry the display name in the progressbar. By default the
+        mAP is logged to the progressbar.
+        """
         super().__init__()
         self.metrics = metrics or []
+        self.metrics_keys_to_log_to_prog_bar = metrics_keys_to_log_to_prog_bar or [("AP (IoU=0.50:0.95) area=all", "mAP")]
 
     def accumulate_metrics(self, preds):
         for metric in self.metrics:
@@ -18,4 +24,9 @@ class LightningModelAdapter(pl.LightningModule, ABC):
         for metric in self.metrics:
             metric_logs = metric.finalize()
             for k, v in metric_logs.items():
-                self.log(f"{metric.name}/{k}", v)
+                for entry in self.metrics_keys_to_log_to_prog_bar:
+                    if entry[0] == k:
+                        self.log(entry[1], v, prog_bar=True)
+                        self.log(f"{metric.name}/{k}", v)
+                    else:
+                        self.log(f"{metric.name}/{k}", v)

--- a/icevision/engines/lightning/lightning_model_adapter.py
+++ b/icevision/engines/lightning/lightning_model_adapter.py
@@ -6,7 +6,11 @@ from icevision.metrics import *
 
 
 class LightningModelAdapter(pl.LightningModule, ABC):
-    def __init__(self, metrics: List[Metric] = None, metrics_keys_to_log_to_prog_bar: List[tuple] = None):
+    def __init__(
+        self,
+        metrics: List[Metric] = None,
+        metrics_keys_to_log_to_prog_bar: List[tuple] = None,
+    ):
         """
         To show a metric in the progressbar a list of tupels can be provided for metrics_keys_to_log_to_prog_bar, the first
         entry has to be the name of the metric to log and the second entry the display name in the progressbar. By default the
@@ -14,7 +18,9 @@ class LightningModelAdapter(pl.LightningModule, ABC):
         """
         super().__init__()
         self.metrics = metrics or []
-        self.metrics_keys_to_log_to_prog_bar = metrics_keys_to_log_to_prog_bar or [("AP (IoU=0.50:0.95) area=all", "mAP")]
+        self.metrics_keys_to_log_to_prog_bar = metrics_keys_to_log_to_prog_bar or [
+            ("AP (IoU=0.50:0.95) area=all", "mAP")
+        ]
 
     def accumulate_metrics(self, preds):
         for metric in self.metrics:

--- a/notebooks/icevision_install.sh
+++ b/notebooks/icevision_install.sh
@@ -1,0 +1,76 @@
+# Pick your installation target: cuda11 or cuda10 or cpu
+# Pick icevision version: if empty, the PyPi release version will be chosen. If you pass `master`, the GitHub master version will be chosen
+
+# Examples
+## Install cuda11  and icevsision master version
+# !bash icevision_install.sh cuda11 master  
+
+## Install cpu and icevsision PyPi version
+# !bash icevision_install.sh cpu 
+
+target="${1}" 
+case ${target} in 
+   cuda10)  
+      echo "Installing icevision + dependencices for ${1}"
+      echo "- Installing torch and its dependencies"
+      pip install torch==1.9.0+cu102 torchvision==0.10.0+cu102 -f https://download.pytorch.org/whl/torch_stable.html --upgrade -q
+
+      echo "- Installing mmcv"
+      pip install mmcv-full==1.3.14 -f https://download.openmmlab.com/mmcv/dist/cu102/torch1.9.0/index.html --upgrade -q    
+      ;; 
+
+   cuda11)  
+      echo "Installing icevision + dependencices for ${1}"
+      echo "- Installing torch and its dependencies"
+      pip install torch==1.9.0+cu111 torchvision==0.10.0+cu111 -f https://download.pytorch.org/whl/torch_stable.html --upgrade 
+
+      echo "- Installing mmcv"
+      pip install mmcv-full==1.3.14 -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.9.0/index.html --upgrade -q  
+    ;;  
+    
+   cpu)  
+      echo "Installing icevision + dependencices for ${1}"
+      echo "- Installing torch and its dependencies"
+      pip install torch=="1.9.0+cpu" torchvision=="0.10.0+cpu" -f https://download.pytorch.org/whl/torch_stable.html  
+
+      echo "- Installing mmcv"
+      pip install mmcv-full=="1.3.14" -f https://download.openmmlab.com/mmcv/dist/cpu/torch1.9.0/index.html --upgrade -q  
+    ;;
+
+   *)  
+      echo "Coud not install icevision. Check out which torch and torchvision versions are compatible with your CUDA version" 
+      exit -1 # Command to come out of the program with status -1
+      ;; 
+esac
+
+
+echo "- Installing mmdet"
+pip install mmdet==2.17.0 --upgrade -q
+
+icevision_version="${2}"
+
+case ${icevision_version} in 
+   master) 
+      echo "- Installing icevision from master"
+      pip install git+git://github.com/airctic/icevision.git\#egg=icevision[all] --upgrade -q
+
+      echo "- Installing icedata from master"      
+      pip install git+git://github.com/airctic/icedata.git --upgrade -q
+
+      echo "- Installing yolov5-icevision" 
+      pip install git+git://github.com/airctic/yolov5-icevision.git  --upgrade -q      
+      ;;
+
+   *) 
+      echo "- Installing icevision from PyPi"
+      pip install icevision[all] --upgrade -q
+
+      echo "- Installing icedata from PyPi"      
+      pip install icedata --upgrade -q
+
+      echo "- Installing yolov5-icevision" 
+      pip install yolov5-icevision --upgrade -q
+      ;;
+  esac 
+
+echo "icevision installation finished!"  

--- a/notebooks/icevision_install.sh.1
+++ b/notebooks/icevision_install.sh.1
@@ -1,0 +1,76 @@
+# Pick your installation target: cuda11 or cuda10 or cpu
+# Pick icevision version: if empty, the PyPi release version will be chosen. If you pass `master`, the GitHub master version will be chosen
+
+# Examples
+## Install cuda11  and icevsision master version
+# !bash icevision_install.sh cuda11 master  
+
+## Install cpu and icevsision PyPi version
+# !bash icevision_install.sh cpu 
+
+target="${1}" 
+case ${target} in 
+   cuda10)  
+      echo "Installing icevision + dependencices for ${1}"
+      echo "- Installing torch and its dependencies"
+      pip install torch==1.9.0+cu102 torchvision==0.10.0+cu102 -f https://download.pytorch.org/whl/torch_stable.html --upgrade -q
+
+      echo "- Installing mmcv"
+      pip install mmcv-full==1.3.14 -f https://download.openmmlab.com/mmcv/dist/cu102/torch1.9.0/index.html --upgrade -q    
+      ;; 
+
+   cuda11)  
+      echo "Installing icevision + dependencices for ${1}"
+      echo "- Installing torch and its dependencies"
+      pip install torch==1.9.0+cu111 torchvision==0.10.0+cu111 -f https://download.pytorch.org/whl/torch_stable.html --upgrade 
+
+      echo "- Installing mmcv"
+      pip install mmcv-full==1.3.14 -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.9.0/index.html --upgrade -q  
+    ;;  
+    
+   cpu)  
+      echo "Installing icevision + dependencices for ${1}"
+      echo "- Installing torch and its dependencies"
+      pip install torch=="1.9.0+cpu" torchvision=="0.10.0+cpu" -f https://download.pytorch.org/whl/torch_stable.html  
+
+      echo "- Installing mmcv"
+      pip install mmcv-full=="1.3.14" -f https://download.openmmlab.com/mmcv/dist/cpu/torch1.9.0/index.html --upgrade -q  
+    ;;
+
+   *)  
+      echo "Coud not install icevision. Check out which torch and torchvision versions are compatible with your CUDA version" 
+      exit -1 # Command to come out of the program with status -1
+      ;; 
+esac
+
+
+echo "- Installing mmdet"
+pip install mmdet==2.17.0 --upgrade -q
+
+icevision_version="${2}"
+
+case ${icevision_version} in 
+   master) 
+      echo "- Installing icevision from master"
+      pip install git+git://github.com/airctic/icevision.git\#egg=icevision[all] --upgrade -q
+
+      echo "- Installing icedata from master"      
+      pip install git+git://github.com/airctic/icedata.git --upgrade -q
+
+      echo "- Installing yolov5-icevision" 
+      pip install git+git://github.com/airctic/yolov5-icevision.git  --upgrade -q      
+      ;;
+
+   *) 
+      echo "- Installing icevision from PyPi"
+      pip install icevision[all] --upgrade -q
+
+      echo "- Installing icedata from PyPi"      
+      pip install icedata --upgrade -q
+
+      echo "- Installing yolov5-icevision" 
+      pip install yolov5-icevision --upgrade -q
+      ;;
+  esac 
+
+echo "icevision installation finished!"  

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,7 @@ dev =
   pytest-cov >=2.10.1,<3
   flake8 >=3.8.3,<4
   pre-commit >=2.8.2,<3
+  pytest-mock >=3.6.1
 
 [flake8]
 # from ci-all-testing.yaml

--- a/tests/engines/lightning/test_lightning_model_adapter.py
+++ b/tests/engines/lightning/test_lightning_model_adapter.py
@@ -1,5 +1,6 @@
 from icevision.engines.lightning import LightningModelAdapter
 
+
 class MockMetric:
     def __init__(self):
         self.name = "MockMetric"
@@ -17,11 +18,13 @@ class DummLightningModelAdapter(LightningModelAdapter):
 
 # test if finalize metrics reports metrics correctly
 def test_finalze_metrics_reports_metrics_correctly(mocker):
-    mocker.patch("icevision.engines.lightning.lightning_model_adapter.LightningModelAdapter.log")
+    mocker.patch(
+        "icevision.engines.lightning.lightning_model_adapter.LightningModelAdapter.log"
+    )
 
     adapter = DummLightningModelAdapter([MockMetric()], [("metric_a", "a")])
     adapter.finalize_metrics()
 
-    adapter.log.assert_any_call('a', 1, prog_bar=True)
-    adapter.log.assert_any_call('MockMetric/metric_a', 1)
-    adapter.log.assert_any_call('MockMetric/metric_b', 2)
+    adapter.log.assert_any_call("a", 1, prog_bar=True)
+    adapter.log.assert_any_call("MockMetric/metric_a", 1)
+    adapter.log.assert_any_call("MockMetric/metric_b", 2)

--- a/tests/engines/lightning/test_lightning_model_adapter.py
+++ b/tests/engines/lightning/test_lightning_model_adapter.py
@@ -1,0 +1,27 @@
+from icevision.engines.lightning import LightningModelAdapter
+
+class MockMetric:
+    def __init__(self):
+        self.name = "MockMetric"
+
+    def accumulate(self):
+        pass
+
+    def finalize(sefl):
+        return {"metric_a": 1, "metric_b": 2}
+
+
+class DummLightningModelAdapter(LightningModelAdapter):
+    pass
+
+
+# test if finalize metrics reports metrics correctly
+def test_finalze_metrics_reports_metrics_correctly(mocker):
+    mocker.patch("icevision.engines.lightning.lightning_model_adapter.LightningModelAdapter.log")
+
+    adapter = DummLightningModelAdapter([MockMetric()], [("metric_a", "a")])
+    adapter.finalize_metrics()
+
+    adapter.log.assert_any_call('a', 1, prog_bar=True)
+    adapter.log.assert_any_call('MockMetric/metric_a', 1)
+    adapter.log.assert_any_call('MockMetric/metric_b', 2)


### PR DESCRIPTION
With this PR the `LightningModelAdapter` will take another `__init__` argument named `metrics_keys_to_log_to_prog_bar` which has to be a list of string tuples with two elements, were the first entry is the name of the metric to log and the second one is the display name.
By default the value will be set to `[("AP (IoU=0.50:0.95) area=all", "mAP")]` which will log the mAP. This will only log the value is the COCOMetric is supplied as a metric! If so it will look like this:

![image](https://user-images.githubusercontent.com/7935340/139528536-f33280e8-313f-4aef-8dab-3e15a690a574.png)

Closes #600