### PR TITLE
(Feature) init coco and via parser with a dict instead of the filepath

### DIFF
--- a/icevision/parsers/coco_parser.py
+++ b/icevision/parsers/coco_parser.py
@@ -31,12 +31,15 @@ def coco(
 class COCOBaseParser(Parser):
     def __init__(
         self,
-        annotations_filepath: Union[str, Path],
+        annotations_filepath: Union[str, Path, dict],
         img_dir: Union[str, Path],
         idmap: Optional[IDMap] = None,
     ):
 
-        self.annotations_dict = json.loads(Path(annotations_filepath).read_bytes())
+        if isinstance(annotations_filepath, dict):
+            self.annotations_dict = annotations_filepath
+        else:
+            self.annotations_dict = json.loads(Path(annotations_filepath).read_bytes())
         self.img_dir = Path(img_dir)
 
         self._record_id2info = {o["id"]: o for o in self.annotations_dict["images"]}

--- a/icevision/parsers/via_parser.py
+++ b/icevision/parsers/via_parser.py
@@ -37,13 +37,16 @@ class VIAParseError(Exception):
 class VIABaseParser(Parser):
     def __init__(
         self,
-        annotations_filepath: Union[str, Path],
+        annotations_filepath: Union[str, Path, dict],
         img_dir: Union[str, Path],
         class_map: ClassMap,
         label_field: str = "label",
     ):
         super().__init__(template_record=self.template_record())
-        self.annotations_dict = json.loads(Path(annotations_filepath).read_bytes())
+        if isinstance(annotations_filepath, dict):
+            self.annotations_dict = annotations_filepath
+        else:
+            self.annotations_dict = json.loads(Path(annotations_filepath).read_bytes())
         self.img_dir = Path(img_dir)
         self.label_field = label_field
         self.class_map = class_map

--- a/tests/parsers/test_coco_parser.py
+++ b/tests/parsers/test_coco_parser.py
@@ -193,3 +193,11 @@ def test_mask_parser(coco_mask_parser):
             243.78,
         ]
     ]
+
+
+def test_coco_base_parser_init_from_dict(coco_dir):
+    annotations_dict = json.load(open(coco_dir / "annotations.json"))
+    parser_init_by_dict = parsers.coco(
+        annotations_dict, coco_dir / "images", mask=False
+    )
+    assert parser_init_by_dict.annotations_dict == annotations_dict

--- a/tests/parsers/test_via_parser.py
+++ b/tests/parsers/test_via_parser.py
@@ -45,3 +45,9 @@ def test_bbox_parser_missing_label(via_dir, via_bbox_class_map):
     )
     with pytest.raises(parsers.VIAParseError, match=r"Could not find.*IMG_4908.*"):
         _ = parser.parse(data_splitter=SingleSplitSplitter())[0]
+
+
+def test_via_base_parser_init_from_dict(via_dir, via_bbox_class_map):
+    annotations_dict = json.load(open(via_dir / "via_bbox.json"))
+    parser_init_by_dict = parsers.via(annotations_dict, via_dir, via_bbox_class_map)
+    assert parser_init_by_dict.annotations_dict == annotations_dict


### PR DESCRIPTION
With this PR the filepath argument for the coco and via parser can be a dict. This is usefull if the annotations are not loaded from disk but from an api.
The name of the init parametr filepath was not changed to not break the api.