### PR TITLE
fix image IO

### DIFF
--- a/icevision/utils/imageio.py
+++ b/icevision/utils/imageio.py
@@ -59,8 +59,8 @@ def get_img_size(filepath: Union[str, Path]) -> ImgSize:
         with PIL.Image.open(filepath) as image:
             image_size = image.size
     except AttributeError as err:
-        im = torchvision.io.read_image(filepath)
-        image_size = tuple(im.shape[-2:][::-1])
+        im = cv2.imread(filepath)
+        image_size = tuple(im.shape[:2][::-1])
 
     try:
         exif = image._getexif()

--- a/icevision/utils/imageio.py
+++ b/icevision/utils/imageio.py
@@ -55,8 +55,12 @@ def get_img_size(filepath: Union[str, Path]) -> ImgSize:
     """
     Returns image (width, height)
     """
-    with PIL.Image.open(filepath) as image:
-        image_size = image.size
+    try:
+        with PIL.Image.open(filepath) as image:
+            image_size = image.size
+    except AttributeError as err:
+        print(f"Failed to load image: {filepath}")
+        raise err
 
     try:
         exif = image._getexif()

--- a/icevision/utils/imageio.py
+++ b/icevision/utils/imageio.py
@@ -56,11 +56,11 @@ def get_img_size(filepath: Union[str, Path]) -> ImgSize:
     Returns image (width, height)
     """
     try:
-        with PIL.Image.open(filepath) as image:
-            image_size = image.size
+        image = PIL.Image.open(filepath)
+        image_size = image.size
     except AttributeError as err:
-        im = cv2.imread(str(filepath))
-        image_size = tuple(im.shape[:2][::-1])
+        image = cv2.imread(str(filepath))
+        image_size = tuple(image.shape[:2][::-1])
 
     try:
         exif = image._getexif()

--- a/icevision/utils/imageio.py
+++ b/icevision/utils/imageio.py
@@ -59,7 +59,7 @@ def get_img_size(filepath: Union[str, Path]) -> ImgSize:
         with PIL.Image.open(filepath) as image:
             image_size = image.size
     except AttributeError as err:
-        im = cv2.imread(filepath)
+        im = cv2.imread(str(filepath))
         image_size = tuple(im.shape[:2][::-1])
 
     try:

--- a/icevision/utils/imageio.py
+++ b/icevision/utils/imageio.py
@@ -59,8 +59,8 @@ def get_img_size(filepath: Union[str, Path]) -> ImgSize:
         with PIL.Image.open(filepath) as image:
             image_size = image.size
     except AttributeError as err:
-        print(f"Failed to load image: {filepath}")
-        raise err
+        im = torchvision.io.read_image(filepath)
+        image_size = tuple(im.shape[-2:][::-1])
 
     try:
         exif = image._getexif()


### PR DESCRIPTION
Fix for using old PIL library which is failing for:
```
AttributeError: module 'PIL.TiffTags' has no attribute 'IFD'
```