### PR TITLE
Properly restore transformed masks after unload

### DIFF
--- a/icevision/models/mmdet/common/mask/dataloaders.py
+++ b/icevision/models/mmdet/common/mask/dataloaders.py
@@ -107,7 +107,9 @@ def _img_meta_mask(record):
 
 def _masks(record):
     if len(record.detection.masks) == 0:
-        raise RuntimeError("Negative samples still needs to be implemented")
+        raise RuntimeError(
+            "Negative samples still needs to be implemented. This error might appear due to cropping, please check your transformations."
+        )
     else:
         mask = record.detection.mask_array.data
         _, h, w = mask.shape

--- a/icevision/tfms/albumentations/albumentations_adapter.py
+++ b/icevision/tfms/albumentations/albumentations_adapter.py
@@ -139,7 +139,8 @@ class AlbumentationsMasksComponent(AlbumentationsAdapterComponent):
         # # set masks from the modified masks array
         rles = []
         for m in masks:
-            rles.append(RLE.from_coco(m.to_coco_rle(*masks.shape[1:])[0]["counts"]))
+            if m.data.any():
+                rles.append(RLE.from_coco(m.to_coco_rle(*masks.shape[1:])[0]["counts"]))
         self._record_component.set_masks(rles)
         # HACK: Not sure if necessary
         self._record_component = None

--- a/icevision/tfms/albumentations/albumentations_adapter.py
+++ b/icevision/tfms/albumentations/albumentations_adapter.py
@@ -140,7 +140,7 @@ class AlbumentationsMasksComponent(AlbumentationsAdapterComponent):
             # set masks from the modified masks array
             rles = []
             for m in masks:
-                rles.append(RLE.from_coco(m.to_coco_rle(*masks.shape[1:])[0]['counts']))
+                rles.append(RLE.from_coco(m.to_coco_rle(*masks.shape[1:])[0]["counts"]))
             self._record_component.set_masks(rles)
         else:
             self._record_component.masks.clear()

--- a/icevision/tfms/albumentations/albumentations_adapter.py
+++ b/icevision/tfms/albumentations/albumentations_adapter.py
@@ -134,8 +134,17 @@ class AlbumentationsMasksComponent(AlbumentationsAdapterComponent):
 
     def collect(self, record):
         masks = self.adapter._filter_attribute(self.adapter._albu_out["masks"])
-        masks = MaskArray(np.array(masks))
-        self._record_component.set_mask_array(masks)
+        if len(masks) > 0:
+            masks = MaskArray(np.array(masks))
+            self._record_component.set_mask_array(masks)
+            # set masks from the modified masks array
+            rles = []
+            for m in masks:
+                rles.append(RLE.from_coco(m.to_coco_rle(*masks.shape[1:])[0]['counts']))
+            self._record_component.set_masks(rles)
+        else:
+            self._record_component.masks.clear()
+            self._record_component.mask_array = None
         # HACK: Not sure if necessary
         self._record_component = None
 

--- a/icevision/tfms/albumentations/albumentations_adapter.py
+++ b/icevision/tfms/albumentations/albumentations_adapter.py
@@ -134,17 +134,13 @@ class AlbumentationsMasksComponent(AlbumentationsAdapterComponent):
 
     def collect(self, record):
         masks = self.adapter._filter_attribute(self.adapter._albu_out["masks"])
-        if len(masks) > 0:
-            masks = MaskArray(np.array(masks))
-            self._record_component.set_mask_array(masks)
-            # set masks from the modified masks array
-            rles = []
-            for m in masks:
-                rles.append(RLE.from_coco(m.to_coco_rle(*masks.shape[1:])[0]["counts"]))
-            self._record_component.set_masks(rles)
-        else:
-            self._record_component.masks.clear()
-            self._record_component.mask_array = None
+        masks = MaskArray(np.array(masks))
+        self._record_component.set_mask_array(masks)
+        # # set masks from the modified masks array
+        rles = []
+        for m in masks:
+            rles.append(RLE.from_coco(m.to_coco_rle(*masks.shape[1:])[0]["counts"]))
+        self._record_component.set_masks(rles)
         # HACK: Not sure if necessary
         self._record_component = None
 

--- a/icevision/visualize/draw_data.py
+++ b/icevision/visualize/draw_data.py
@@ -418,7 +418,10 @@ def draw_pred(
 
 
 def draw_bbox(
-    img: np.ndarray, bbox: BBox, color: Tuple[int, int, int], gap: bool = True,
+    img: np.ndarray,
+    bbox: BBox,
+    color: Tuple[int, int, int],
+    gap: bool = True,
 ):
     """Draws a box on an image with a given color.
     # Arguments
@@ -601,7 +604,9 @@ def draw_segmentation_mask(
 
 
 def draw_keypoints(
-    img: np.ndarray, kps: KeyPoints, color: Tuple[int, int, int],
+    img: np.ndarray,
+    kps: KeyPoints,
+    color: Tuple[int, int, int],
 ):
     x, y, v = kps.x, kps.y, kps.visible
 

--- a/icevision/visualize/draw_data.py
+++ b/icevision/visualize/draw_data.py
@@ -91,7 +91,13 @@ def draw_sample(
         if task == "segmentation":
             cm = rand_cmap(sample.segmentation.class_map.num_classes, verbose=False)
             if composite.mask_array is None:
-                mask = composite.masks[0].to_mask(None, None).data
+                if len(composite.masks) > 1:
+                    masks = composite.masks[0].to_mask(img.shape[0], img.shape[1]).data
+                else:
+                    masks = [
+                        mask.to_mask(img.shape[1], img.shape[0]).data
+                        for mask in composite.masks
+                    ]
             else:
                 mask = composite.mask_array
             return draw_segmentation_mask(img, mask, cm, display_mask=display_mask)
@@ -115,7 +121,13 @@ def draw_sample(
         # HACK
         if hasattr(composite, "masks"):
             if composite.mask_array is None:
-                masks = composite.masks[0].to_mask(None, None).data
+                if len(composite.masks) > 1:
+                    masks = composite.masks[0].to_mask(img.shape[0], img.shape[1]).data
+                else:
+                    masks = [
+                        mask.to_mask(img.shape[1], img.shape[0]).data
+                        for mask in composite.masks
+                    ]
             else:
                 masks = composite.mask_array
         else:
@@ -406,10 +418,7 @@ def draw_pred(
 
 
 def draw_bbox(
-    img: np.ndarray,
-    bbox: BBox,
-    color: Tuple[int, int, int],
-    gap: bool = True,
+    img: np.ndarray, bbox: BBox, color: Tuple[int, int, int], gap: bool = True,
 ):
     """Draws a box on an image with a given color.
     # Arguments
@@ -592,9 +601,7 @@ def draw_segmentation_mask(
 
 
 def draw_keypoints(
-    img: np.ndarray,
-    kps: KeyPoints,
-    color: Tuple[int, int, int],
+    img: np.ndarray, kps: KeyPoints, color: Tuple[int, int, int],
 ):
     x, y, v = kps.x, kps.y, kps.visible
 

--- a/tests/transforms/test_albu_transform.py
+++ b/tests/transforms/test_albu_transform.py
@@ -173,3 +173,34 @@ def test_get_transform() -> None:
     assert isinstance(get_transform(transforms, "Normalize"), Normalize)
     assert isinstance(get_transform(transforms, "Pad"), PadIfNeeded)
     assert isinstance(get_transform(transforms, "Longest"), LongestMaxSize)
+
+
+def test_mask_transform_with_unload(records, check_attributes_on_component):
+
+    tfm = tfms.A.Adapter([tfms.A.HorizontalFlip(p=1.0)])
+    tfm_ds = Dataset(records, tfm=tfm)
+
+    tfmed = tfm_ds[0]
+    original_mask_array = tfmed.detection.mask_array
+
+    assert tfmed.detection.mask_array.data.any()
+
+    tfmed.unload()
+
+    assert not tfmed.detection.mask_array
+
+    tfmed.detection.mask_array = MaskArray.from_masks(
+        tfmed.detection.masks, tfmed.height, tfmed.width
+    )
+
+    assert np.array_equal(tfmed.detection.mask_array.data, original_mask_array.data)
+    check_attributes_on_component(tfmed)
+
+    # # assert orignal record was not changed
+    record = records[0]
+    assert len(record.detection.label_ids) == 1
+    assert len(record.detection.bboxes) == 1
+    assert len(record.detection.masks) == 1
+    assert len(record.detection.iscrowds) == 1
+    assert len(record.detection.areas) == 1
+    check_attributes_on_component(record)


### PR DESCRIPTION
Stores the results of applying transforms to the `detection.masks` of a record, which allows the `mask_array` to be properly reconstructed later (after `.unload()` has been called on the record).

Fixes #978. 