### PR TITLE
refactor: Fixed the bug to add neck modules properly

### DIFF
--- a/icevision/models/mmdet/utils.py
+++ b/icevision/models/mmdet/utils.py
@@ -47,7 +47,10 @@ def param_groups(model):
         layers += [getattr(body, l) for l in body.res_layers]
 
     # add the neck module if it exists (DETR doesn't have a neck module)
-    layers += [model.neck for name in model.named_modules() if name == "neck"]
+    for name, _ in model.named_modules():
+        if name == "neck":
+            layers += [model.neck]
+            break
 
     # add the head
     if isinstance(model, SingleStageDetector):


### PR DESCRIPTION
Fix a bug introduced by the DETR implementation. The problem was that when iterating the `named_modules()`, it return both the name and the module, but it was iterated as it was a list so the statement  `if name == 'neck'` was never going to be True.