### PR TITLE
Add YOLACT support from mmdet

### DIFF
--- a/icevision/models/mmdet/common/mask/single_stage/__init__.py
+++ b/icevision/models/mmdet/common/mask/single_stage/__init__.py
@@ -1,0 +1,2 @@
+from icevision.models.mmdet.common.mask import *
+from icevision.models.mmdet.common.mask.single_stage.model import *

--- a/icevision/models/mmdet/common/mask/single_stage/model.py
+++ b/icevision/models/mmdet/common/mask/single_stage/model.py
@@ -1,0 +1,29 @@
+__all__ = ["model"]
+
+from turtle import back
+from icevision import backbones
+from icevision.imports import *
+from mmcv import Config
+from mmdet.models import build_detector
+from mmcv.runner import load_checkpoint
+from icevision.models.mmdet.utils import *
+from icevision.models.mmdet.common.utils import *
+
+
+def model(
+    backbone: MMDetBackboneConfig,
+    num_classes: int,
+    checkpoints_path: Optional[Union[str, Path]] = "checkpoints",
+    force_download=False,
+    cfg_options=None,
+) -> nn.Module:
+
+    return build_model(
+        model_type="one_stage_detector_mask",
+        backbone=backbone,
+        num_classes=num_classes,
+        pretrained=backbone.pretrained,
+        checkpoints_path=checkpoints_path,
+        force_download=force_download,
+        cfg_options=cfg_options,
+    )

--- a/icevision/models/mmdet/common/utils.py
+++ b/icevision/models/mmdet/common/utils.py
@@ -70,6 +70,11 @@ def build_model(
         cfg.model.roi_head.bbox_head.num_classes = num_classes - 1
         cfg.model.roi_head.mask_head.num_classes = num_classes - 1
 
+    if model_type == "one_stage_detector_mask":
+        cfg.model.bbox_head.num_classes = num_classes - 1
+        cfg.model.segm_head.num_classes = num_classes - 1
+        cfg.model.mask_head.num_classes = num_classes - 1
+
     if (pretrained == False) or (weights_path is not None):
         cfg.model.pretrained = None
 

--- a/icevision/models/mmdet/models/__init__.py
+++ b/icevision/models/mmdet/models/__init__.py
@@ -16,3 +16,4 @@ from icevision.models.mmdet.models import sabl
 
 # segmentation
 from icevision.models.mmdet.models import mask_rcnn
+from icevision.models.mmdet.models import yolact

--- a/icevision/models/mmdet/models/yolact/__init__.py
+++ b/icevision/models/mmdet/models/yolact/__init__.py
@@ -1,0 +1,25 @@
+from icevision.models.mmdet.models.yolact import backbones
+from icevision.models.mmdet.common.mask.single_stage import *
+from icevision.models.interpretation import Interpretation, _move_to_device
+from icevision.models.mmdet.common.interpretation_utils import (
+    sum_losses_mmdet,
+    loop_mmdet,
+)
+
+_LOSSES_DICT = {
+    "loss_rpn_cls": [],
+    "loss_rpn_bbox": [],
+    "loss_cls": [],
+    "loss_bbox": [],
+    "loss_mask": [],
+    "loss_total": [],
+}
+
+interp = Interpretation(
+    losses_dict=_LOSSES_DICT,
+    valid_dl=valid_dl,
+    infer_dl=infer_dl,
+    predict_from_dl=predict_from_dl,
+)
+
+interp._loop = loop_mmdet

--- a/icevision/models/mmdet/models/yolact/backbones/__init__.py
+++ b/icevision/models/mmdet/models/yolact/backbones/__init__.py
@@ -1,0 +1,1 @@
+from icevision.models.mmdet.models.yolact.backbones.resnet_fpn import *

--- a/icevision/models/mmdet/models/yolact/backbones/resnet_fpn.py
+++ b/icevision/models/mmdet/models/yolact/backbones/resnet_fpn.py
@@ -1,4 +1,4 @@
-__all__ = ["yolact_r50_1x8_coco"]
+__all__ = ["r50_1x8_coco", "r50_8x8_coco", "r101_1x8_coco"]
 
 from icevision.imports import *
 from icevision.models.mmdet.utils import *
@@ -12,7 +12,17 @@ class YOLOACTMMDetBackboneConfig(MMDetBackboneConfig):
 base_config_path = mmdet_configs_path / "yolact"
 base_weights_url = "http://download.openmmlab.com/mmdetection/v2.0/yolact"
 
-yolact_r50_1x8_coco = YOLOACTMMDetBackboneConfig(
+r50_1x8_coco = YOLOACTMMDetBackboneConfig(
     config_path=base_config_path / "yolact_r50_1x8_coco.py",
     weights_url=f"{base_weights_url}/yolact_r50_1x8_coco/yolact_r50_1x8_coco_20200908-f38d58df.pth",
+)
+
+r50_8x8_coco = YOLOACTMMDetBackboneConfig(
+    config_path=base_config_path / "yolact_r50_8x8_coco.py",
+    weights_url=f"{base_weights_url}/yolact_r50_8x8_coco/yolact_r50_8x8_coco_20200908-ca34f5db.pth",
+)
+
+r101_1x8_coco = YOLOACTMMDetBackboneConfig(
+    config_path=base_config_path / "yolact_r101_1x8_coco.py",
+    weights_url=f"{base_weights_url}/yolact_r101_1x8_coco/yolact_r101_1x8_coco_20200908-4cbe9101.pth",
 )

--- a/icevision/models/mmdet/models/yolact/backbones/resnet_fpn.py
+++ b/icevision/models/mmdet/models/yolact/backbones/resnet_fpn.py
@@ -1,0 +1,18 @@
+__all__ = ["yolact_r50_1x8_coco"]
+
+from icevision.imports import *
+from icevision.models.mmdet.utils import *
+
+
+class YOLOACTMMDetBackboneConfig(MMDetBackboneConfig):
+    def __init__(self, **kwargs):
+        super().__init__(model_name="yolact", **kwargs)
+
+
+base_config_path = mmdet_configs_path / "yolact"
+base_weights_url = "http://download.openmmlab.com/mmdetection/v2.0/yolact"
+
+yolact_r50_1x8_coco = YOLOACTMMDetBackboneConfig(
+    config_path=base_config_path / "yolact_r50_1x8_coco.py",
+    weights_url=f"{base_weights_url}/yolact_r50_1x8_coco/yolact_r50_1x8_coco_20200908-f38d58df.pth",
+)

--- a/icevision/models/mmdet/utils.py
+++ b/icevision/models/mmdet/utils.py
@@ -67,6 +67,13 @@ def param_groups(model):
     # add the head
     if isinstance(model, SingleStageDetector):
         layers += [model.bbox_head]
+
+        # YOLACT has mask_head and segm_head
+        if getattr(model, "mask_head", False):
+            layers += [model.mask_head]
+        if getattr(model, "segm_head", False):
+            layers += [model.segm_head]
+
     elif isinstance(model, TwoStageDetector):
         layers += [nn.Sequential(model.rpn_head, model.roi_head)]
     else:


### PR DESCRIPTION
This PR adds YOLACT: Real-time Instance Segmentation, a single stage instance segmentation model, into IceVision.

Paper: https://arxiv.org/abs/1904.02689
Configs/models: https://github.com/open-mmlab/mmdetection/blob/master/configs/yolact/README.md