### PR TITLE
Adding Coco Metric for inference

### DIFF
--- a/icevision/metrics/coco_metric/coco_metric.py
+++ b/icevision/metrics/coco_metric/coco_metric.py
@@ -58,10 +58,26 @@ class COCOMetric(Metric):
         self._reset()
         return logs
 
+    def metric_from_preds(
+        self,
+        preds: List[
+            Prediction
+        ],  # Prediction holds both the ground truth and the prediction records
+        print_summary: bool = False,
+    ) -> Dict[str, float]:
+
+        gt_list = [pred.ground_truth for pred in preds]
+        preds_list = [pred.pred for pred in preds]
+
+        logs = self.metric(
+            records=gt_list, preds=preds_list, print_summary=print_summary
+        )
+        return logs
+
     def metric(
         self,
-        records,
-        preds,
+        records,  # Ground Truth records
+        preds,  # Prediction records
         print_summary: bool = False,
     ) -> Dict[str, float]:
         with CaptureStdout():

--- a/icevision/metrics/coco_metric/coco_metric.py
+++ b/icevision/metrics/coco_metric/coco_metric.py
@@ -1,7 +1,6 @@
 __all__ = [
     "COCOMetric",
     "COCOMetricType",
-    "metric",
 ]
 
 from icevision.imports import *
@@ -53,20 +52,18 @@ class COCOMetric(Metric):
 
     def finalize(self) -> Dict[str, float]:
         logs = self.metric(
-            records=self._records, 
-            preds=self._preds, 
-            print_summary=self.print_summary
+            records=self._records, preds=self._preds, print_summary=self.print_summary
         )
 
         self._reset()
         return logs
 
     def metric(
-        self, 
-        records, 
+        self,
+        records,
         preds,
         print_summary: bool = False,
-        ) -> Dict[str, float]:
+    ) -> Dict[str, float]:
         with CaptureStdout():
             coco_eval = create_coco_eval(
                 records=records,

--- a/icevision/models/mmdet/utils.py
+++ b/icevision/models/mmdet/utils.py
@@ -81,9 +81,9 @@ def param_groups(model):
         layers += [model.bbox_head]
 
         # YOLACT has mask_head and segm_head
-        if getattr(model, "mask_head"):
+        if getattr(model, "mask_head", False):
             layers += [model.mask_head]
-        if getattr(model, "segm_head"):
+        if getattr(model, "segm_head", False):
             layers += [model.segm_head]
 
     elif isinstance(model, TwoStageDetector):


### PR DESCRIPTION
I added some convenient methods to easily calculate the COCO metric at inference when ground truth records are available

```
infer_dl = model_type.infer_dl(valid_ds, batch_size=4, shuffle=False)
preds = model_type.predict_from_dl(model, infer_dl, keep_images=True)
```
```
inference_metric = COCOMetric(metric_type=COCOMetricType.bbox)
```
Get the COCO metric from the Predictions object:
```
logs = inference_metric.metric_from_preds(preds, print_summary=True)
```

You call also separately pass the ground_truth and the predictions:
```
gt_list = [pred.ground_truth for pred in preds]
preds_list = [pred.pred for pred in preds]

logs = inference_metric.metric(gt_list, preds_list, print_summary=True)
```
