### PR TITLE
Support for DICOM images

### DIFF
--- a/icevision/imports.py
+++ b/icevision/imports.py
@@ -71,6 +71,8 @@ if SoftDependencies.wandb:
 if SoftDependencies.sklearn:
     import sklearn
 
+if SoftDependencies.pydicom:
+    import pydicom
 
 # TODO: Stop importing partial from fastcore and move this to utils
 class partial:

--- a/icevision/soft_dependencies.py
+++ b/icevision/soft_dependencies.py
@@ -27,6 +27,7 @@ class _SoftDependencies:
         self.sklearn = soft_import("sklearn")
         self.sahi = soft_import("sahi")
         self.fiftyone = soft_import("fiftyone")
+        self.pydicom = soft_import("pydicom")
 
     def check(self) -> Dict[str, bool]:
         return self.__dict__.copy()

--- a/icevision/utils/imageio.py
+++ b/icevision/utils/imageio.py
@@ -7,7 +7,6 @@ __all__ = [
     "plot_grid",
 ]
 
-import pydicom
 from icevision.imports import *
 from PIL import ExifTags
 
@@ -25,14 +24,18 @@ for _EXIF_ORIENTATION_TAG in ExifTags.TAGS.keys():
 
 
 def open_dicom(filename) -> PIL.Image:
+    bits_stored_key = 0x00280101
+    photometric_inter_key = 0x00280004
+
     dcm = pydicom.dcmread(filename)
-    bits_stored = dcm[0x00280101]
+    bits_stored = dcm[bits_stored_key]
 
     img = dcm.pixel_array
+
     # Check the photometric interpretation
     # MONOCHROME1: Greyscale ranges from bright to dark
     # MONOCHROME2: Greyscale ranges from dark to right
-    if dcm[0x00280004].value == "MONOCHROME1":
+    if dcm[photometric_inter_key].value == "MONOCHROME1":
         img = 2 ** bits_stored - img
 
     # Apply a VOI LUT transformation (if the image does not

--- a/icevision/utils/imageio.py
+++ b/icevision/utils/imageio.py
@@ -40,10 +40,6 @@ def open_dicom(filename) -> PIL.Image:
     # unchanged)
     img = pydicom.pixel_data_handlers.apply_voi_lut(img, dcm)
 
-    # TODO: Convert to 8 bits if the image is 16 bit?
-    # if bits_stored == 16:
-    #    img = img / 65535.
-    #    img = (img * 255).astype(int)
     img = PIL.Image.fromarray(img)
 
     return img
@@ -54,10 +50,7 @@ def open_img(fn, gray=False, ignore_exif: bool = False) -> PIL.Image.Image:
     "Open an image from disk `fn` as a PIL Image"
     color = "L" if gray else "RGB"
 
-    if ".dcm" in str(fn):
-        image = open_dicom(str(fn))
-    else:
-        image = PIL.Image.open(str(fn))
+    image = PIL.Image.open(str(fn))
 
     if not ignore_exif:
         image = PIL.ImageOps.exif_transpose(image)
@@ -67,7 +60,11 @@ def open_img(fn, gray=False, ignore_exif: bool = False) -> PIL.Image.Image:
 
 def open_gray_scale_image(fn):
     "Opens an radiographic/gray scale image, stacks the channel to represent a RGB image and returns is as a 32bit float array."
-    img = np.array(PIL.Image.open(fn))
+    if ".dcm" in str(fn).lower():
+        img = open_dicom(str(fn))
+    else:
+        img = PIL.Image.open(str(fn))
+
     img = np.dstack([img, img, img])
     img = img.astype(np.float32)
     return img
@@ -87,7 +84,7 @@ def get_img_size(filepath: Union[str, Path]) -> ImgSize:
     """
     Returns image (width, height)
     """
-    if ".dcm" in str(filepath):
+    if ".dcm" in str(filepath).lower():
         image = open_dicom(str(filepath))
     else:
         image = PIL.Image.open(str(filepath))

--- a/tests/utils/test_soft_dependencies.py
+++ b/tests/utils/test_soft_dependencies.py
@@ -24,4 +24,5 @@ def test_soft_dependencies():
         "yolov5": True,
         "sahi": True,
         "fiftyone": True,
+        "pydicom": False,
     }


### PR DESCRIPTION
This PR adds support for DICOM images. I am preparing a notebook to show an example on [this](https://www.kaggle.com/c/rsna-pneumonia-detection-challenge/data?select=stage_2_train_labels.csv) dataset. I had to create the annotations.json because it is not provided. Also I have a few questions:
- Can icevision handle 16bit images? There are some medical images that are 16bit. Also, some albumentations transform cannot handle need the image to be in a 8bit format. I have already prepared the code to convert the image from 16bit to 8bit.
- Where should I add a new dependency? To handle the DICOM format I use the `pydicom` library.