### PR TITLE
don't open image on get_img_size

### DIFF
--- a/icevision/utils/imageio.py
+++ b/icevision/utils/imageio.py
@@ -89,10 +89,10 @@ def get_img_size(filepath: Union[str, Path]) -> ImgSize:
     """
     if ".dcm" in str(filepath).lower():
         image = open_dicom(str(filepath))
+        image_size = image.size
     else:
-        image = PIL.Image.open(str(filepath))
-
-    image_size = image.size
+        with PIL.Image.open(str(filepath)) as image:
+            image_size = image.size
 
     try:
         exif = image._getexif()


### PR DESCRIPTION
fixes for normal images, but the problem still persists for dicom files