### PR TITLE
Remove manual `torch.no_grad` and train eval mode in LightningModule

### DIFF
--- a/icevision/models/mmdet/lightning/model_adapter.py
+++ b/icevision/models/mmdet/lightning/model_adapter.py
@@ -52,12 +52,10 @@ class MMDetModelAdapter(LightningModelAdapter, ABC):
     def validation_step(self, batch, batch_idx):
         data, records = batch
 
-        self.model.eval()
-        with torch.no_grad():
-            outputs = self.model.train_step(data=data, optimizer=None)
-            raw_preds = self.model.forward_test(
-                imgs=[data["img"]], img_metas=[data["img_metas"]]
-            )
+        outputs = self.model.train_step(data=data, optimizer=None)
+        raw_preds = self.model.forward_test(
+            imgs=[data["img"]], img_metas=[data["img_metas"]]
+        )
 
         preds = self.convert_raw_predictions(
             batch=data, raw_preds=raw_preds, records=records
@@ -66,9 +64,6 @@ class MMDetModelAdapter(LightningModelAdapter, ABC):
 
         for k, v in outputs["log_vars"].items():
             self.log(f"valid/{k}", v)
-
-        # TODO: is train and eval model automatically set by lighnting?
-        self.model.train()
 
     def validation_epoch_end(self, outs):
         self.finalize_metrics()

--- a/icevision/models/ross/efficientdet/lightning/model_adapter.py
+++ b/icevision/models/ross/efficientdet/lightning/model_adapter.py
@@ -41,15 +41,14 @@ class ModelAdapter(LightningModelAdapter, ABC):
     def validation_step(self, batch, batch_idx):
         (xb, yb), records = batch
 
-        with torch.no_grad():
-            raw_preds = self(xb, yb)
-            preds = efficientdet.convert_raw_predictions(
-                batch=(xb, yb),
-                raw_preds=raw_preds["detections"],
-                records=records,
-                detection_threshold=0.0,
-            )
-            loss = efficientdet.loss_fn(raw_preds, yb)
+        raw_preds = self(xb, yb)
+        preds = efficientdet.convert_raw_predictions(
+            batch=(xb, yb),
+            raw_preds=raw_preds["detections"],
+            records=records,
+            detection_threshold=0.0,
+        )
+        loss = efficientdet.loss_fn(raw_preds, yb)
 
         self.accumulate_metrics(preds)
 

--- a/icevision/models/torchvision/lightning_model_adapter.py
+++ b/icevision/models/torchvision/lightning_model_adapter.py
@@ -36,17 +36,16 @@ class RCNNModelAdapter(LightningModelAdapter, ABC):
 
     def validation_step(self, batch, batch_idx):
         (xb, yb), records = batch
-        with torch.no_grad():
-            self.train()
-            train_preds = self(xb, yb)
-            loss = loss_fn(train_preds, yb)
+        self.train()
+        train_preds = self(xb, yb)
+        loss = loss_fn(train_preds, yb)
 
-            self.eval()
-            raw_preds = self(xb)
-            preds = self.convert_raw_predictions(
-                batch=batch, raw_preds=raw_preds, records=records
-            )
-            self.accumulate_metrics(preds=preds)
+        self.eval()
+        raw_preds = self(xb)
+        preds = self.convert_raw_predictions(
+            batch=batch, raw_preds=raw_preds, records=records
+        )
+        self.accumulate_metrics(preds=preds)
 
         self.log("val_loss", loss)
 

--- a/icevision/models/ultralytics/yolov5/lightning/model_adapter.py
+++ b/icevision/models/ultralytics/yolov5/lightning/model_adapter.py
@@ -42,16 +42,15 @@ class ModelAdapter(LightningModelAdapter, ABC):
     def validation_step(self, batch, batch_idx):
         (xb, yb), records = batch
 
-        with torch.no_grad():
-            inference_out, training_out = self(xb)
-            preds = yolov5.convert_raw_predictions(
-                batch=xb,
-                raw_preds=inference_out,
-                records=records,
-                detection_threshold=0.001,
-                nms_iou_threshold=0.6,
-            )
-            loss = self.compute_loss(training_out, yb)[0]
+        inference_out, training_out = self(xb)
+        preds = yolov5.convert_raw_predictions(
+            batch=xb,
+            raw_preds=inference_out,
+            records=records,
+            detection_threshold=0.001,
+            nms_iou_threshold=0.6,
+        )
+        loss = self.compute_loss(training_out, yb)[0]
 
         self.accumulate_metrics(preds)
 


### PR DESCRIPTION
PL LightningModule automatically sets train and eval mode and `torch.no_grad` during the training and validation steps.