### PR TITLE
Update resnet_fpn.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/icevision/models/mmdet/models/vfnet/backbones/resnet_fpn.py
+++ b/icevision/models/mmdet/models/vfnet/backbones/resnet_fpn.py
@@ -15,10 +15,9 @@ from icevision.models.mmdet.models.vfnet.backbones.backbone_config import (
     MMDetVFNETBackboneConfig,
 )
 
+
 base_config_path = mmdet_configs_path / "vfnet"
-base_weights_url = (
-    "https://openmmlab.oss-cn-hangzhou.aliyuncs.com/mmdetection/v2.0/vfnet"
-)
+base_weights_url = "https://download.openmmlab.com/mmdetection/v2.0/vfnet"
 
 resnet50_fpn_1x = MMDetVFNETBackboneConfig(
     config_path=base_config_path / "vfnet_r50_fpn_1x_coco.py",


### PR DESCRIPTION
This PR fixes the error `UnpicklingError: invalid load key, '<'` when loading a VFNet model.

Closes https://github.com/airctic/icevision/issues/1104