### PR TITLE
update black version in github workflow

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black==20.8b1
+        pip install black==22.3.0
 
     - name: Check Black formatting
       run: black --check .


### PR DESCRIPTION
With our current version, `black` formatting check fails with the following error

```bash
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.[7](https://github.com/airctic/icevision/runs/6884156099?check_suite_focus=true#step:5:8).13/x64/bin/black", line [8](https://github.com/airctic/icevision/runs/6884156099?check_suite_focus=true#step:5:9), in <module>
    sys.exit(patched_main())
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/black/__init__.py", line 6606, in patched_main
    patch_click()
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/black/__init__.py", line 65[9](https://github.com/airctic/icevision/runs/6884156099?check_suite_focus=true#step:5:10)5, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/opt/hostedtoolcache/Python/3.7.[13](https://github.com/airctic/icevision/runs/6884156099?check_suite_focus=true#step:5:14)/x64/lib/python3.7/site-packages/click/__init__.py)
Error: Process completed with exit code 1.
```

Related issue - https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click