### PR TITLE
Update checkpoint URL - Swin backbone for MaskRCNN

### DIFF
--- a/icevision/models/mmdet/models/mask_rcnn/backbones/swin.py
+++ b/icevision/models/mmdet/models/mask_rcnn/backbones/swin.py
@@ -15,9 +15,7 @@ class MMDetSwinBackboneConfig(MMDetBackboneConfig):
 
 
 base_config_path = mmdet_configs_path / "swin"
-base_weights_url = (
-    "https://openmmlab.oss-cn-hangzhou.aliyuncs.com/mmdetection/v2.0/swin"
-)
+base_weights_url = "http://download.openmmlab.com/mmdetection/v2.0/swin"
 
 
 mask_rcnn_swin_t_p4_w7_fpn_1x_coco = MMDetSwinBackboneConfig(


### PR DESCRIPTION
This PR updates the URL for the Swin Transformer backbone used in

```python
model_type = models.mmdet.mask_rcnn
backbone = model_type.backbones.mask_rcnn_swin_t_p4_w7_fpn_1x_coco
```
