### PR TITLE
Update black version in setup.cfg and pyproject.toml

### DIFF
--- a/_pyproject.toml
+++ b/_pyproject.toml
@@ -52,7 +52,7 @@ default=true
 
 
 [tool.poetry.dev-dependencies]
-black = "==20.8b1"
+black = "==22.3.0"
 pytest = ">=6,<7"
 keras-autodoc = "==0.6.0"
 mkdocs = ">=1.1.2,<2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ all =
 dev =
     icevision[all]
     keras-autodoc ==0.6.0
-    black ==20.8b1
+    black ==22.3.0
     pytest >=6,<7
     mkdocs >=1.1.2,<2
     mkdocs-material >=7.3.1,<8


### PR DESCRIPTION
Updating black version throughout the repo. `black==20.8b1`  throws an error like the following:

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.13/x64/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/black/__init__.py", line 6606, in patched_main
    patch_click()
  File "/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/black/__init__.py", line 6595, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/click/__init__.py)
Error: Process completed with exit code 1.
```

Error goes away with `black==22.3.0`.

More info https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click