### PR TITLE
Fix Colab installation by installing the right torchtext version

### DIFF
--- a/icevision_install.sh
+++ b/icevision_install.sh
@@ -13,7 +13,7 @@ case ${target} in
    cuda10)  
       echo "Installing icevision + dependencices for ${1}"
       echo "- Installing torch and its dependencies"
-      pip install torch==1.10.0+cu102 torchvision==0.11.1+cu102 -f https://download.pytorch.org/whl/torch_stable.html --upgrade -q
+      pip install torch==1.10.0+cu102 torchvision==0.11.1+cu102 torchtext==0.11.0 -f https://download.pytorch.org/whl/torch_stable.html --upgrade -q
 
       echo "- Installing mmcv"
       pip install mmcv-full==1.3.17 -f https://download.openmmlab.com/mmcv/dist/cu102/torch1.10.0/index.html --upgrade -q    
@@ -22,7 +22,7 @@ case ${target} in
    cuda11)  
       echo "Installing icevision + dependencices for ${1}"
       echo "- Installing torch and its dependencies"
-      pip install torch==1.10.0+cu111 torchvision==0.11.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html --upgrade 
+      pip install torch==1.10.0+cu111 torchvision==0.11.1+cu111 torchtext==0.11.0 -f https://download.pytorch.org/whl/torch_stable.html --upgrade 
 
       echo "- Installing mmcv"
       pip install mmcv-full==1.3.17 -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.10.0/index.html --upgrade -q  
@@ -31,7 +31,7 @@ case ${target} in
    cpu)  
       echo "Installing icevision + dependencices for ${1}"
       echo "- Installing torch and its dependencies"
-      pip install torch=="1.10.0+cpu" torchvision=="0.11.1+cpu" -f https://download.pytorch.org/whl/torch_stable.html  
+      pip install torch=="1.10.0+cpu" torchvision=="0.11.1+cpu" torchtext==0.11.0 -f https://download.pytorch.org/whl/torch_stable.html  
 
       echo "- Installing mmcv"
       pip install mmcv-full=="1.3.17" -f https://download.openmmlab.com/mmcv/dist/cpu/torch1.10.0/index.html --upgrade -q  


### PR DESCRIPTION
the Colab installation fails because the default `torchtext` version is higher.

This will fix the issue by installing the right `torchtext` version

`torchtext==0.11.0`