### PR TITLE
Update tests to use newer pytorch lightning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,8 @@ inference =
 
 all =
     fastai >=2.5.2,<2.6
-    pytorch-lightning >=1.4.5
+    pytorch-lightning >=1.7.0
+#     pytorch-lightning >=1.4.5
     wandb >=0.10.7
 
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,8 +48,7 @@ inference =
 
 all =
     fastai >=2.5.2,<2.6
-    pytorch-lightning >=1.7.0
-#     pytorch-lightning >=1.4.5
+    pytorch-lightning >=1.5.0
     wandb >=0.10.7
 
 dev =

--- a/tests/models/efficient_det/lightning/test_test.py
+++ b/tests/models/efficient_det/lightning/test_test.py
@@ -33,10 +33,10 @@ def test_lightining_efficientdet_test(
     light_model = light_model_cls(fridge_efficientdet_model, metrics=metrics)
     trainer = pl.Trainer(
         max_epochs=1,
-        weights_summary=None,
+        enable_model_summary=False,
         num_sanity_val_steps=0,
         logger=False,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
     )
 
     trainer.test(light_model, valid_dl)

--- a/tests/models/efficient_det/lightning/test_train.py
+++ b/tests/models/efficient_det/lightning/test_train.py
@@ -31,10 +31,10 @@ def test_lightining_efficientdet_train(
     light_model = light_model_cls(model=fridge_efficientdet_model, metrics=metrics)
     trainer = pl.Trainer(
         max_epochs=1,
-        weights_summary=None,
+        enable_model_summary=False,
         num_sanity_val_steps=0,
         logger=False,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
     )
 
     trainer.fit(light_model, train_dl, valid_dl)

--- a/tests/models/efficient_det/lightning/test_validate.py
+++ b/tests/models/efficient_det/lightning/test_validate.py
@@ -34,10 +34,10 @@ def test_lightining_efficientdet_validate(
     light_model = light_model_cls(fridge_efficientdet_model, metrics=metrics)
     trainer = pl.Trainer(
         max_epochs=1,
-        weights_summary=None,
+        enable_model_summary=False,
         num_sanity_val_steps=0,
         logger=False,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
     )
 
     trainer.validate(light_model, valid_dl)

--- a/tests/models/fastai/unet/lightning/test_test.py
+++ b/tests/models/fastai/unet/lightning/test_test.py
@@ -21,10 +21,10 @@ def test_fastai_unet_test(camvid_ds, backbone):
 
     trainer = pl.Trainer(
         max_epochs=1,
-        weights_summary=None,
+        enable_model_summary=False,
         num_sanity_val_steps=0,
         logger=False,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
     )
     trainer.test(light_model, valid_dl)
 

--- a/tests/models/fastai/unet/lightning/test_train.py
+++ b/tests/models/fastai/unet/lightning/test_train.py
@@ -24,10 +24,10 @@ def test_fastai_unet_train(camvid_ds, backbone):
 
     trainer = pl.Trainer(
         max_epochs=1,
-        weights_summary=None,
+        enable_model_summary=False,
         num_sanity_val_steps=0,
         logger=False,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
     )
     trainer.fit(light_model, train_dl, valid_dl)
 

--- a/tests/models/fastai/unet/lightning/test_validate.py
+++ b/tests/models/fastai/unet/lightning/test_validate.py
@@ -21,10 +21,10 @@ def test_fastai_unet_validate(camvid_ds, backbone):
 
     trainer = pl.Trainer(
         max_epochs=1,
-        weights_summary=None,
+        enable_model_summary=False,
         num_sanity_val_steps=0,
         logger=False,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
     )
     trainer.validate(light_model, valid_dl)
 

--- a/tests/models/mmdet/test_model.py
+++ b/tests/models/mmdet/test_model.py
@@ -64,10 +64,10 @@ class TestBboxModels:
         light_model = LitModel(model)
         trainer = pl.Trainer(
             max_epochs=1,
-            weights_summary=None,
+            enable_model_summary=False,
             num_sanity_val_steps=0,
             logger=False,
-            checkpoint_callback=False,
+            enable_checkpointing=False,
         )
 
         trainer.fit(light_model, train_dl, valid_dl)
@@ -144,10 +144,10 @@ class TestBboxModels:
         light_model = LitModel(model)
         trainer = pl.Trainer(
             max_epochs=1,
-            weights_summary=None,
+            enable_model_summary=False,
             num_sanity_val_steps=0,
             logger=False,
-            checkpoint_callback=False,
+            enable_checkpointing=False,
         )
 
         trainer.validate(light_model, valid_dl)
@@ -225,10 +225,10 @@ class TestBboxModels:
         light_model = LitModel(model)
         trainer = pl.Trainer(
             max_epochs=1,
-            weights_summary=None,
+            enable_model_summary=False,
             num_sanity_val_steps=0,
             logger=False,
-            checkpoint_callback=False,
+            enable_checkpointing=False,
         )
 
         trainer.test(light_model, valid_dl)
@@ -339,9 +339,9 @@ def test_mmdet_mask_models_light(mask_dls_model):
     light_model = LitModel(model)
     trainer = pl.Trainer(
         max_epochs=1,
-        weights_summary=None,
+        enable_model_summary=False,
         num_sanity_val_steps=0,
         logger=False,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
     )
     trainer.fit(light_model, train_dl, valid_dl)

--- a/tests/models/torchvision_models/faster_rcnn/lightning/test_test.py
+++ b/tests/models/torchvision_models/faster_rcnn/lightning/test_test.py
@@ -32,10 +32,10 @@ def test_lightining_faster_rcnn_test(
     light_model = light_model_cls(fridge_faster_rcnn_model, metrics=metrics)
     trainer = pl.Trainer(
         max_epochs=1,
-        weights_summary=None,
+        enable_model_summary=False,
         num_sanity_val_steps=0,
         logger=False,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
     )
 
     trainer.test(light_model, valid_dl)

--- a/tests/models/torchvision_models/faster_rcnn/lightning/test_train.py
+++ b/tests/models/torchvision_models/faster_rcnn/lightning/test_train.py
@@ -31,10 +31,10 @@ def test_lightining_faster_rcnn_train(
 
     trainer = pl.Trainer(
         max_epochs=1,
-        weights_summary=None,
+        enable_model_summary=False,
         num_sanity_val_steps=0,
         logger=False,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
     )
     trainer.fit(light_model, train_dl, valid_dl)
 

--- a/tests/models/torchvision_models/faster_rcnn/lightning/test_validate.py
+++ b/tests/models/torchvision_models/faster_rcnn/lightning/test_validate.py
@@ -32,10 +32,10 @@ def test_lightining_faster_rcnn_validate(
     light_model = light_model_cls(fridge_faster_rcnn_model, metrics=metrics)
     trainer = pl.Trainer(
         max_epochs=1,
-        weights_summary=None,
+        enable_model_summary=False,
         num_sanity_val_steps=0,
         logger=False,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
     )
 
     trainer.validate(light_model, valid_dl)

--- a/tests/models/torchvision_models/keypoints_rcnn/lightning/test_test.py
+++ b/tests/models/torchvision_models/keypoints_rcnn/lightning/test_test.py
@@ -30,10 +30,10 @@ def test_lightining_keypoints_rcnn_test(ochuman_keypoints_dls, light_model_cls):
     light_model = light_model_cls(model)
     trainer = pl.Trainer(
         max_epochs=1,
-        weights_summary=None,
+        enable_model_summary=False,
         num_sanity_val_steps=0,
         logger=False,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
     )
 
     trainer.test(light_model, valid_dl)

--- a/tests/models/torchvision_models/keypoints_rcnn/lightning/test_train.py
+++ b/tests/models/torchvision_models/keypoints_rcnn/lightning/test_train.py
@@ -28,10 +28,10 @@ def test_lightining_keypoints_rcnn_train(ochuman_keypoints_dls, light_model_cls)
 
     trainer = pl.Trainer(
         max_epochs=1,
-        weights_summary=None,
+        enable_model_summary=False,
         num_sanity_val_steps=0,
         logger=False,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
     )
     trainer.fit(light_model, train_dl, valid_dl)
 

--- a/tests/models/torchvision_models/keypoints_rcnn/lightning/test_validate.py
+++ b/tests/models/torchvision_models/keypoints_rcnn/lightning/test_validate.py
@@ -30,10 +30,10 @@ def test_lightining_keypoints_rcnn_validate(ochuman_keypoints_dls, light_model_c
     light_model = light_model_cls(model)
     trainer = pl.Trainer(
         max_epochs=1,
-        weights_summary=None,
+        enable_model_summary=False,
         num_sanity_val_steps=0,
         logger=False,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
     )
 
     trainer.validate(light_model, valid_dl)

--- a/tests/models/torchvision_models/retinanet/lightning/test_test.py
+++ b/tests/models/torchvision_models/retinanet/lightning/test_test.py
@@ -32,10 +32,10 @@ def test_lightining_retinanet_test(
     light_model = light_model_cls(fridge_retinanet_model, metrics=metrics)
     trainer = pl.Trainer(
         max_epochs=1,
-        weights_summary=None,
+        enable_model_summary=False,
         num_sanity_val_steps=0,
         logger=False,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
     )
 
     trainer.test(light_model, valid_dl)

--- a/tests/models/torchvision_models/retinanet/lightning/test_train.py
+++ b/tests/models/torchvision_models/retinanet/lightning/test_train.py
@@ -29,10 +29,10 @@ def test_lightining_retinanet_train(
 
     trainer = pl.Trainer(
         max_epochs=1,
-        weights_summary=None,
+        enable_model_summary=False,
         num_sanity_val_steps=0,
         logger=False,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
     )
     trainer.fit(light_model, train_dl, valid_dl)
 

--- a/tests/models/torchvision_models/retinanet/lightning/test_validate.py
+++ b/tests/models/torchvision_models/retinanet/lightning/test_validate.py
@@ -32,10 +32,10 @@ def test_lightining_retinanet_validate(
     light_model = light_model_cls(fridge_retinanet_model, metrics=metrics)
     trainer = pl.Trainer(
         max_epochs=1,
-        weights_summary=None,
+        enable_model_summary=False,
         num_sanity_val_steps=0,
         logger=False,
-        checkpoint_callback=False,
+        enable_checkpointing=False,
     )
 
     trainer.validate(light_model, valid_dl)


### PR DESCRIPTION
Parameters passed to pl.Trainer such a `weights_summary` and `checkpoint_callback` were deprecated since pl 1.5.0 and removed in 1.7.0. This PR updates test functions in order to support new pl verision.