### PR TITLE
Fixed issue #1139

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,3 +17,4 @@ dependencies:
       - --find-links https://download.openmmlab.com/mmcv/dist/cu102/torch1.10.0/index.html
       - mmcv-full==1.3.17
       - mmdet==2.17.0
+      - setuptools==59.5.0


### PR DESCRIPTION
For some OS version, the previous `setuptools` package version was creating issues when importing both icevision and icedata libraries.
I setted the version of `setuptools` to `59.5.0`.