### PR TITLE
Make COCO exports remember original img resolutions

### DIFF
--- a/icevision/data/convert_records_to_coco_style.py
+++ b/icevision/data/convert_records_to_coco_style.py
@@ -132,6 +132,15 @@ def export_batch_inferences_as_coco_annotations(
         )
 
     coco_style_preds = convert_preds_to_coco_style(preds)
+    imgs_array = [PIL.Image.open(Path(fname)) for fname in img_files]
+
+    sizes = [{'x': img._size[0],
+              'y': img._size[1]} for img in imgs_array]
+
+    for idx, image in enumerate(coco_style_preds['images']):
+        coco_style_preds['images'][idx]['width'] = sizes[idx]['x']
+        coco_style_preds['images'][idx]['height'] = sizes[idx]['y']
+
     finalized_pseudo_labels = {**addl_info, **coco_style_preds}
 
     # Serialize

--- a/icevision/data/convert_records_to_coco_style.py
+++ b/icevision/data/convert_records_to_coco_style.py
@@ -134,12 +134,11 @@ def export_batch_inferences_as_coco_annotations(
     coco_style_preds = convert_preds_to_coco_style(preds)
     imgs_array = [PIL.Image.open(Path(fname)) for fname in img_files]
 
-    sizes = [{'x': img._size[0],
-              'y': img._size[1]} for img in imgs_array]
+    sizes = [{"x": img._size[0], "y": img._size[1]} for img in imgs_array]
 
-    for idx, image in enumerate(coco_style_preds['images']):
-        coco_style_preds['images'][idx]['width'] = sizes[idx]['x']
-        coco_style_preds['images'][idx]['height'] = sizes[idx]['y']
+    for idx, image in enumerate(coco_style_preds["images"]):
+        coco_style_preds["images"][idx]["width"] = sizes[idx]["x"]
+        coco_style_preds["images"][idx]["height"] = sizes[idx]["y"]
 
     finalized_pseudo_labels = {**addl_info, **coco_style_preds}
 


### PR DESCRIPTION
Fixes a flaw in the `export_batch_inferences_as_coco_annotations` function. Previously, the function did not preserve the original image resolutions (which are not always 512x512). With this fix, the original resolutions are re-inserted before exporting COCO-style annotation JSONs.