### PR TITLE
Added support for already encoded RLEs

### DIFF
--- a/icevision/parsers/coco_parser.py
+++ b/icevision/parsers/coco_parser.py
@@ -105,10 +105,13 @@ class COCOBBoxParser(COCOBaseParser):
 class COCOMaskParser(COCOBBoxParser):
     def masks(self, o) -> List[MaskArray]:
         seg = o["segmentation"]
-        if o["iscrowd"]:
-            return [RLE.from_coco(seg["counts"])]
-        else:
+        if isinstance(seg, list):
             return [Polygon(seg)]
+        elif isinstance(seg, dict):
+            if isinstance(seg["counts"], list):
+                return [RLE.from_coco(seg["counts"])]
+            elif isinstance(seg["counts"], str):
+                return [EncodedRLEs([seg])]
 
     def template_record(self) -> BaseRecord:
         record = super().template_record()


### PR DESCRIPTION
Some COCO Datasets already have encoded RLEs so I added support to the parser to handle cases where they are already encoded. I also removed the use of iscrowd as a method of determining wether it is RLE or Polygon data as in my opinion that is not the proper use of that tag in the dictionary as the mask storage method doesn't always correlate with iscrowd.

Here is the issue that I brought up.
https://github.com/airctic/icevision/issues/1165#issue-1513291363